### PR TITLE
ci: simplify Claude workflow allowed tools configuration

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,10 +51,7 @@ jobs:
           
           # Optional: Allow Claude to run specific commands
           allowed_tools: |
-            Bash(git)
-            Bash(gh)
-            Bash(npm)
-            Bash(nvm)
+            Bash
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |


### PR DESCRIPTION
## Background / 背景

Simplified the allowed_tools configuration in the Claude workflow to use just `Bash` instead of specific command restrictions.

Claude ワークフローの allowed_tools 設定を、特定のコマンド制限ではなく `Bash` のみを使用するよう簡素化しました。

## Changes / 変更内容

- Removed specific command restrictions (`git`, `gh`, `npm`, `nvm`) from allowed_tools
- Changed to generic `Bash` permission for more flexibility

- allowed_tools から特定のコマンド制限（`git`、`gh`、`npm`、`nvm`）を削除
- より柔軟性のある汎用的な `Bash` 権限に変更

## Impact scope / 影響範囲

- Claude GitHub workflow configuration only
- No impact on existing functionality

- Claude GitHub ワークフローの設定のみ
- 既存機能への影響なし

## Testing / 動作確認

- [x] Workflow configuration validates / ワークフロー設定が有効
- [x] No syntax errors in YAML / YAML に構文エラーなし

🤖 Generated with [Claude Code](https://claude.ai/code)