### PR TITLE
ci: add path filters to test-scripts workflow

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -3,8 +3,24 @@ name: Test Scripts
 on:
   push:
     branches: [ main ]
+    paths:
+      - ".config/**"
+      - ".github/**"
+      - ".vimrc"
+      - ".zshrc"
+      - "Brewfile"
+      - "install.sh"
+      - "link.sh"
   pull_request:
     branches: [ main ]
+    paths:
+      - ".config/**"
+      - ".github/**"
+      - ".vimrc"
+      - ".zshrc"
+      - "Brewfile"
+      - "install.sh"
+      - "link.sh"
 
 jobs:
   test-macos:


### PR DESCRIPTION
## Background / 背景

The test-scripts workflow was running on every push and pull request regardless of which files were changed, leading to unnecessary CI runs.
test-scriptsワークフローは、どのファイルが変更されたかに関わらず、すべてのpushとpull requestで実行されていたため、不要なCI実行が発生していました。

## Changes / 変更内容

Added path filters to the test-scripts workflow to run tests only when relevant files are modified:
- Configuration files under `.config/`
- GitHub workflow files under `.github/`
- Shell configuration files (`.vimrc`, `.zshrc`)
- Installation scripts (`install.sh`, `link.sh`)
- `Brewfile`

test-scriptsワークフローにパスフィルターを追加し、関連するファイルが変更された場合のみテストを実行するようにしました：
- `.config/`配下の設定ファイル
- `.github/`配下のGitHubワークフローファイル
- シェル設定ファイル（`.vimrc`、`.zshrc`）
- インストールスクリプト（`install.sh`、`link.sh`）
- `Brewfile`

## Impact scope / 影響範囲

This change improves CI efficiency by avoiding unnecessary test runs when unrelated files (like README.md or documentation) are modified.
この変更により、関連のないファイル（README.mdやドキュメントなど）が変更された際の不要なテスト実行を回避し、CIの効率が向上します。

## Testing / 動作確認

- [x] Verified the workflow syntax is correct / ワークフローの構文が正しいことを確認
- [x] Path patterns match the files that should trigger tests / パスパターンがテストをトリガーすべきファイルと一致することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)