### PR TITLE
feat: add sheldon plugins.toml configuration

### DIFF
--- a/.config/sheldon/plugins.toml
+++ b/.config/sheldon/plugins.toml
@@ -1,0 +1,23 @@
+# `sheldon` configuration file
+# ----------------------------
+#
+# You can modify this file directly or you can use one of the following
+# `sheldon` commands which are provided to assist in editing the config file:
+#
+# - `sheldon add` to add a new plugin to the config file
+# - `sheldon edit` to open up the config file in the default editor
+# - `sheldon remove` to remove a plugin from the config file
+#
+# See the documentation for more https://github.com/rossmacarthur/sheldon#readme
+
+shell = "zsh"
+
+[plugins]
+
+# For example:
+#
+# [plugins.base16]
+# github = "chriskempson/base16-shell"
+
+[plugins.zsh-autosuggestions]
+github = "zsh-users/zsh-autosuggestions"

--- a/.github/scripts/test-config.sh
+++ b/.github/scripts/test-config.sh
@@ -52,6 +52,14 @@ else
   exit_code=1
 fi
 
+# Check Sheldon configuration
+if test -f .config/sheldon/plugins.toml; then
+  echo "✓ Sheldon plugins.toml exists"
+else
+  echo "✗ Sheldon plugins.toml missing"
+  exit_code=1
+fi
+
 # Validate JSON files
 echo "Validating JSON files..."
 if python3 -m json.tool .config/karabiner/assets/complex_modifications/personal_hagaspa.json > /dev/null 2>&1; then

--- a/link.sh
+++ b/link.sh
@@ -11,6 +11,7 @@ files_and_paths=(
   ".config/karabiner/assets/complex_modifications/personal_hagaspa.json:~/.config/karabiner/assets/complex_modifications/personal_hagaspa.json"
   ".config/ghostty/config:~/.config/ghostty/config"
   ".config/cursor/settings.json:~/Library/Application Support/Cursor/User/settings.json"
+  ".config/sheldon/plugins.toml:~/.config/sheldon/plugins.toml"
   ".zshrc:~/.zshrc"
   ".vimrc:~/.vimrc"
 )


### PR DESCRIPTION
## Background / 背景

Added sheldon plugins.toml configuration file to the dotfiles repository for better shell plugin management.
dotfilesリポジトリにsheldon plugins.tomlの設定ファイルを追加し、シェルプラグイン管理を改善しました。

## Changes / 変更内容

- Added `.config/sheldon/plugins.toml` configuration file with zsh-autosuggestions plugin
- Updated `link.sh` to create symbolic link for sheldon configuration
- Updated test script to verify sheldon configuration exists

- zsh-autosuggestionsプラグインを含む`.config/sheldon/plugins.toml`設定ファイルを追加
- sheldon設定用のシンボリックリンクを作成するように`link.sh`を更新
- sheldon設定の存在を確認するテストスクリプトを更新

## Impact scope / 影響範囲

This change only affects users who use sheldon for shell plugin management. The configuration will be automatically linked when running `./link.sh`.
この変更はシェルプラグイン管理にsheldonを使用するユーザーのみに影響します。`./link.sh`実行時に設定が自動的にリンクされます。

## Testing / 動作確認

- [x] Verified sheldon configuration file is correctly copied to repository / リポジトリへのsheldon設定ファイルのコピーを確認
- [x] Confirmed link.sh creates symbolic link for sheldon configuration / link.shがsheldon設定のシンボリックリンクを作成することを確認
- [x] Updated test script validates sheldon configuration existence / テストスクリプトがsheldon設定の存在を検証することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)