### PR TITLE
docs: add documentation for workspace navigation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,28 @@ This repository includes Claude Code configuration:
 ## Custom Commands
 
 The `.config/zsh/command.sh` includes powerful custom functions:
-- `hagaspa()` - Smart workspace navigation with Git context awareness
+- `hagaspa()` - Navigate to hagaspa workspace with intelligent path completion based on Git remote
+- `OLTAInc()` - Navigate to OLTAInc workspace with intelligent path completion based on Git remote
+- `olta` - Alias for OLTAInc() function
 - `gw()` - Git worktree management with automatic organization
 - `fzf-select-history*()` - Enhanced command history search
+
+### Workspace Navigation Functions
+
+#### hagaspa() Function
+The `hagaspa()` function provides intelligent workspace navigation for hagaspa repositories:
+- Automatically detects if you're in a HagaSpa Git repository and navigates to the matching workspace
+- Supports path completion with prefix matching (e.g., `hagaspa dot` → `dotfiles` directory)
+- Falls back to the main hagaspa workspace when called without arguments outside a Git repository
+- Workspace structure: `~/workspaces/hagaspa/[repository-name]`
+
+#### OLTAInc() Function and olta Alias
+The `OLTAInc()` function and its alias `olta` provide intelligent workspace navigation for OLTAInc repositories:
+- Automatically detects if you're in an OLTAInc Git repository and navigates to the matching workspace
+- Supports path completion with prefix matching (e.g., `OLTAInc ba` or `olta ba` → `backend` directory)
+- Falls back to the main OLTAInc workspace when called without arguments outside a Git repository
+- Workspace structure: `~/workspaces/OLTAInc/[repository-name]`
+- Both `OLTAInc` and `olta` commands work identically with full tab completion support
 
 ## Customization
 


### PR DESCRIPTION
## Background / 背景

Added comprehensive documentation for the workspace navigation functions to help users understand their capabilities.
ワークスペースナビゲーション機能の包括的なドキュメントを追加し、ユーザーがその機能を理解できるようにしました。

## Changes / 変更内容

- Added detailed documentation for `hagaspa()` function
- Added detailed documentation for `OLTAInc()` function  
- Added documentation for `olta` alias
- Organized workspace navigation functions under a dedicated section

- `hagaspa()` 関数の詳細なドキュメントを追加
- `OLTAInc()` 関数の詳細なドキュメントを追加
- `olta` エイリアスのドキュメントを追加
- ワークスペースナビゲーション機能を専用セクションに整理

## Impact scope / 影響範囲

Documentation only - no code changes
ドキュメントのみ - コードの変更なし

## Testing / 動作確認

- [x] README renders correctly in markdown / READMEがmarkdownで正しく表示される
- [x] All function descriptions are accurate / すべての関数の説明が正確である

🤖 Generated with [Claude Code](https://claude.ai/code)