### PR TITLE
feat: add vim-style navigation with left_control modifier to Karabiner

### DIFF
--- a/.config/karabiner/assets/complex_modifications/personal_hagaspa.json
+++ b/.config/karabiner/assets/complex_modifications/personal_hagaspa.json
@@ -102,6 +102,87 @@
                     ]
                 }
             ]
+        },
+        {
+            "description": "left_control + j/k/l/h to arrow keys",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "j",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_control"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "down_arrow"
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "k",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_control"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "up_arrow"
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "l",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_control"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_arrow"
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "h",
+                        "modifiers": {
+                            "mandatory": [
+                                "left_control"
+                            ],
+                            "optional": [
+                                "any"
+                            ]
+                        }
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_arrow"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION

## Background / 背景

Added vim-style navigation shortcuts to Karabiner-Elements configuration for improved keyboard navigation efficiency.
Karabiner-Elementsの設定にvimスタイルのナビゲーションショートカットを追加し、キーボードナビゲーションの効率を向上させました。

## Changes / 変更内容

Added new key mappings for arrow key navigation using left_control modifier:
- Control+h → left arrow
- Control+j → down arrow
- Control+k → up arrow  
- Control+l → right arrow

左コントロール修飾キーを使用した矢印キーナビゲーションの新しいキーマッピングを追加:
- Control+h → 左矢印
- Control+j → 下矢印
- Control+k → 上矢印
- Control+l → 右矢印

## Impact scope / 影響範囲

Only affects users who have the personal_hagaspa Karabiner complex modification enabled. No impact on other configurations or system behavior.
personal_hagaspaのKarabiner複雑な修飾設定を有効にしているユーザーのみに影響します。他の設定やシステムの動作には影響しません。

## Testing / 動作確認

- [x] Verified Control+h/j/k/l produce arrow key events / Control+h/j/k/lが矢印キーイベントを生成することを確認
- [x] Tested in various applications (terminal, browser, text editor) / 様々なアプリケーション（ターミナル、ブラウザ、テキストエディタ）でテスト
- [x] Confirmed no conflicts with existing key mappings / 既存のキーマッピングとの競合がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)