### PR TITLE
docs: add settings.sh documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ cd ~/workspaces/hagaspa/dotfiles
 
 # Create symbolic links for configuration files
 ./link.sh
+
+# Configure macOS system settings
+./settings.sh
 ```
 
 ## What's Included
@@ -49,6 +52,11 @@ Installs Homebrew, all brew packages from Brewfile, and Google Cloud CLI.
 
 ### `link.sh`
 Creates symbolic links for configuration files from this repository to their expected locations in your home directory. Existing files are backed up with a `.bak` extension.
+
+### `settings.sh`
+Configures macOS system settings for optimal development experience. Currently includes:
+- Disables press-and-hold for keys in favor of key repeat (allows holding keys to repeat instead of showing accent menu)
+- Requires system restart for changes to take effect
 
 ## Requirements
 


### PR DESCRIPTION
## Background / 背景

Added documentation for the settings.sh script to improve repository usability and completeness.
settings.shスクリプトのドキュメントを追加し、リポジトリの使いやすさと完全性を向上させました。

## Changes / 変更内容

- Added settings.sh description in the Scripts section of README.md
- Added settings.sh execution command in the Quick Start section
- README.mdのScriptsセクションにsettings.shの説明を追加
- Quick Startセクションにsettings.shの実行コマンドを追加

## Impact scope / 影響範囲

Documentation only - no functional changes to the codebase.
ドキュメントのみの変更 - コードベースの機能的な変更はありません。

## Testing / 動作確認

- [x] Verified README.md renders correctly / README.mdが正しく表示されることを確認
- [x] Confirmed all script references are accurate / すべてのスクリプト参照が正確であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)