### PR TITLE
feat(fzf): add tmux popup for fzf integration

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -13,3 +13,4 @@ export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
 export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"
 export FZF_CTRL_T_OPTS="--preview 'bat --color=always {}'"
 export FZF_ALT_C_COMMAND='fd --type d --hidden --follow --exclude .git'
+export FZF_TMUX_OPTS="-p 80%,70%"


### PR DESCRIPTION
## Background / 背景

tmux でペイン分割時に Ctrl+T の fzf + bat プレビューが狭くて見づらい問題があった。

## Changes / 変更内容

`FZF_TMUX_OPTS="-p 80%,70%"` を追加し、fzf を tmux popup（display-popup）で起動するように変更。画面中央にオーバーレイ表示されるため、ペイン幅に依存しなくなる。

## Impact scope / 影響範囲

tmux 内での fzf 起動方法（Ctrl+T, Alt+C など）。tmux 外では影響なし。

## Testing / 動作確認

- [x] tmux 内で Ctrl+T を実行し、ポップアップで fzf が表示されることを確認
- [x] ポップアップ内で bat プレビューが正常に表示されることを確認
- [x] ファイル選択後、コマンドラインにパスが挿入されることを確認