### PR TITLE
feat(zsh): improve git switch aliases with dynamic default branch

### DIFF
--- a/.config/zsh/alias.sh
+++ b/.config/zsh/alias.sh
@@ -10,8 +10,9 @@ alias olta="z ~/workspaces/OLTAInc"
 # git aliases
 alias ga='git add'
 alias ga.='git add .'
-alias gb='git switch -'
-alias gbm='git switch main && git pull'
+alias gb='git switch'
+alias gb-='git switch -'
+alias gbm='git switch $(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed "s@^refs/remotes/origin/@@" || echo main) && git pull'
 alias gbc='git switch -c'
 alias gd='git add -N . && git diff'
 alias gs='git status --short --branch'


### PR DESCRIPTION
## Background / 背景

`gb` で直前のブランチに戻る挙動だったが、特定ブランチへの切り替え時に `git switch` を明示的に叩くのが冗長だった。また `gbm` が `main` 固定で、OLTAInc の古いリポジトリ（`master` がデフォルト）で使えなかった。

## Changes / 変更内容

- `gb` → `git switch` のショートハンドに変更（`gb feature/xxx` で切り替え可能に）
- `gb-` → `git switch -`（直前のブランチに戻る）を新設
- `gbm` → `git symbolic-ref` でリモートのデフォルトブランチを自動検出するように変更

## Impact scope / 影響範囲

zsh の git エイリアス。既存の `gb` の使い方が変わるため、`gb` 単体で直前のブランチに戻る操作は `gb-` に変更が必要。

## Testing / 動作確認

- [x] `gb <branch-name>` でブランチ切り替えができることを確認
- [x] `gb-` で直前のブランチに戻れることを確認
- [x] `gbm` で main がデフォルトのリポジトリで正常に動作することを確認
- [x] `gbm` で master がデフォルトのリポジトリで正常に動作することを確認