### PR TITLE
feat(zsh): add syntax highlighting and improve completion settings

### DIFF
--- a/.config/sheldon/plugins.toml
+++ b/.config/sheldon/plugins.toml
@@ -21,3 +21,6 @@ shell = "zsh"
 
 [plugins.zsh-autosuggestions]
 github = "zsh-users/zsh-autosuggestions"
+
+[plugins.zsh-syntax-highlighting]
+github = "zsh-users/zsh-syntax-highlighting"

--- a/.zshrc
+++ b/.zshrc
@@ -1,7 +1,11 @@
 # Completions
-autoload -Uz compinit && compinit
+autoload -Uz compinit && compinit -C
 zstyle ":completion:*:commands" rehash 1
 zstyle ':completion:*' menu select=2
+zstyle ':completion:*' matcher-list \
+  'm:{a-zA-Z}={A-Za-z}' \
+  'r:|[._-]=* r:|=*' \
+  'l:|=* r:|=*'
 
 # source
 source ~/.config/zsh/alias.sh
@@ -18,6 +22,15 @@ eval "$(starship init zsh)"
 eval "$(sheldon source)"
 eval "$(atuin init zsh)"
 eval "$(mise activate zsh)"
+
+# zsh-syntax-highlighting: only highlight unknown commands in red
+ZSH_HIGHLIGHT_STYLES[unknown-token]='fg=red'
+ZSH_HIGHLIGHT_STYLES[command]='none'
+ZSH_HIGHLIGHT_STYLES[builtin]='none'
+ZSH_HIGHLIGHT_STYLES[alias]='none'
+ZSH_HIGHLIGHT_STYLES[function]='none'
+ZSH_HIGHLIGHT_STYLES[precommand]='none'
+ZSH_HIGHLIGHT_STYLES[reserved-word]='none'
 
 # host-specific config
 local host_config="$HOME/.config/zsh/hosts/$(hostname -s).sh"


### PR DESCRIPTION
## Background / 背景

zsh-syntax-highlighting の導入と補完設定の改善を行う。コマンド入力時のタイプミス検知（不明コマンドの赤色表示）とパスの下線表示を有効にし、補完の大文字小文字柔軟マッチと compinit キャッシュを追加する。

## Changes / 変更内容

- sheldon に zsh-syntax-highlighting プラグインを追加
- syntax highlighting のスタイルをカスタマイズ（不明コマンドのみ赤、それ以外はデフォルト色）
- 補完の matcher-list を追加（大文字小文字・区切り文字の柔軟マッチ）
- compinit に -C フラグを追加（キャッシュ有効化でシェル起動を高速化）

## Impact scope / 影響範囲

- `.zshrc` の補完設定と syntax highlighting 設定
- `.config/sheldon/plugins.toml` のプラグイン構成

## Testing / 動作確認

- [x] 存在するコマンドがデフォルト色（白）で表示される
- [x] 不明なコマンドが赤色で表示される
- [x] ファイルパスに下線が表示される
- [x] 大文字小文字を区別しない補完が動作する