### PR TITLE
chore(tmux): increase yazi popup height from 60% to 80%

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -49,7 +49,7 @@ bind c new-window -c '#{pane_current_path}'
 # yazi を popup で開く (popup は passthrough 非対応のため新セッション経由)
 # 選択したファイルパスを元のペイン (Helix 等) に :open で送る
 # https://github.com/sxyazi/yazi/issues/2308#issuecomment-2731102243
-bind y run-shell -b 'tmux display-popup -d "#{pane_current_path}" -w 80% -h 60% -E "bash ~/.config/helix/yazi-picker.sh #{pane_id}"'
+bind y run-shell -b 'tmux display-popup -d "#{pane_current_path}" -w 80% -h 80% -E "bash ~/.config/helix/yazi-picker.sh #{pane_id}"'
 
 # エスケープシーケンスの待機時間を0にする（キー入力の応答性向上）
 set -sg escape-time 0


### PR DESCRIPTION
## Background / 背景

yazi の popup ウィンドウの高さが 60% では狭く、ファイル一覧の視認性が十分でなかったため、80% に拡大する。

## Changes / 変更内容

- tmux の yazi popup 表示高さを `-h 60%` から `-h 80%` に変更

## Impact scope / 影響範囲

- tmux 上で `prefix + y` で yazi を popup 表示する際のウィンドウサイズのみ

## Testing / 動作確認

- [x] `prefix + y` で yazi popup が 80% の高さで表示されることを確認