### PR TITLE
fix(ghostty): disable cmd+d split keybinds

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -6,3 +6,7 @@ font-size = 13
 
 macos-option-as-alt = true
 macos-titlebar-style = hidden
+
+# 分割は tmux (Ctrl+b, % / ") で行うため無効化。右 Cmd 単押し→D の誤爆対策も兼ねる
+keybind = cmd+d=unbind
+keybind = cmd+shift+d=unbind


### PR DESCRIPTION
## Background / 背景

Karabiner Elements で右 Cmd 単押しを `japanese_kana` にマッピングしているが、右 Cmd をタップ→D を素早く押すと、Karabiner が単独押しと判定できず Cmd+D が送出され、Ghostty のデフォルト `cmd+d = new_split:right` で画面が縦分割されてしまう事象が数日に一回発生していた。

## Changes / 変更内容

`.config/ghostty/config` で `cmd+d` と `cmd+shift+d` を `unbind` に設定。画面分割は tmux の prefix (`Ctrl+b, %` / `Ctrl+b, "`) で行うため Ghostty 側の分割ショートカットは不要。

## Impact scope / 影響範囲

- Ghostty の `cmd+d`（縦分割）と `cmd+shift+d`（水平分割）が無効化される
- 他アプリへの影響なし（Ghostty 設定のみ）

## Testing / 動作確認

- [x] Ghostty 再起動（または `Cmd+Shift+,` でリロード）後に `cmd+d` を押しても縦分割されないことを確認
- [x] `cmd+shift+d` でも水平分割されないことを確認
- [x] tmux の `Ctrl+b, %` による縦分割は従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)