### PR TITLE
fix(ghostty): disable cmd+w keybind

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -10,3 +10,6 @@ macos-titlebar-style = hidden
 # 分割は tmux (Ctrl+b, % / ") で行うため無効化。右 Cmd 単押し→D の誤爆対策も兼ねる
 keybind = cmd+d=unbind
 keybind = cmd+shift+d=unbind
+
+# cmd+w での終了を無効化（誤爆対策）
+keybind = cmd+w=unbind


### PR DESCRIPTION
## Background / 背景

Ghostty で `cmd+w` を押すとウィンドウが終了してしまい、誤爆することがあった。

## Changes / 変更内容

`.config/ghostty/config` に `keybind = cmd+w=unbind` を追加し、`cmd+w` のデフォルト挙動を無効化した。

## Impact scope / 影響範囲

- Ghostty の `cmd+w` キーバインドのみ
- 他の設定・キーバインドには影響なし

## Testing / 動作確認

- [x] Ghostty を再起動して `cmd+w` が効かないことを確認する / Restart Ghostty and confirm cmd+w does nothing
- [x] 既存の `cmd+d` / `cmd+shift+d` の無効化が維持されていることを確認する / Confirm existing cmd+d disables remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)