### PR TITLE
fix(cursor): pin cmd+1/2/3 to focus editor groups

### DIFF
--- a/.config/cursor/keybindings.json
+++ b/.config/cursor/keybindings.json
@@ -5,6 +5,18 @@
         "command": "composerMode.agent"
     },
     {
+        "key": "cmd+1",
+        "command": "workbench.action.focusFirstEditorGroup"
+    },
+    {
+        "key": "cmd+2",
+        "command": "workbench.action.focusSecondEditorGroup"
+    },
+    {
+        "key": "cmd+3",
+        "command": "workbench.action.focusThirdEditorGroup"
+    },
+    {
         "key": "shift+enter",
         "command": "workbench.action.terminal.sendSequence",
         "args": {


### PR DESCRIPTION
## Background / 背景

Cursor の "Open chat as editor tabs" を有効化すると、内部のコンテキストキー `cursor.chatEditorGroup.enabled` が `true` となり、デフォルトの `cmd+1` (`workbench.action.focusFirstEditorGroup`) が when 句 `notEquals("cursor.chatEditorGroup.enabled", true)` で**意図的に無効化**される。`cmd+2` 以降には同じ when 句が無く非対称となり、左ペインへの戻り操作だけが機能しなくなる現象に遭遇した。

設定 UI で当該トグルを OFF にすれば一時的に解消するが、今後 Cursor が AI 連動の when 句で類似のハイジャックを行う可能性があるため、**頻繁に使うがコアではない**エディタグループ操作だけ明示的にユーザー定義しておく方針とする。ユーザー定義のキーバインドはビルトインより優先されるため、コンテキストキーの状態に左右されない。

## Changes / 変更内容

`.config/cursor/keybindings.json` に以下 3 件を追加：

- `cmd+1` → `workbench.action.focusFirstEditorGroup`
- `cmd+2` → `workbench.action.focusSecondEditorGroup`
- `cmd+3` → `workbench.action.focusThirdEditorGroup`

`cmd+s`/`cmd+p`/`cmd+f` のような枯れたコアショートカットは含めない（コマンド ID リネーム時に静かに腐るリスクの方が大きいため）。

## Impact scope / 影響範囲

- Cursor のキーバインドのみ
- 他の拡張・既存バインドへの影響なし
- VS Code 本家でも同コマンド ID が有効なので、将来の移行時にもそのまま機能する

## Testing / 動作確認

- [x] `./.github/scripts/test-config.sh` が通過することを確認
- [x] Cursor を再読込せずに `cmd+1`/`cmd+2`/`cmd+3` がそれぞれ該当エディタグループへフォーカス移動することを確認
- [x] `cursor.chatEditorGroup.enabled` が `true` の状態でも `cmd+1` が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)