### PR TITLE
feat(cursor): bind cmd+e to toggle between two recent editors

### DIFF
--- a/.config/cursor/keybindings.json
+++ b/.config/cursor/keybindings.json
@@ -5,6 +5,16 @@
         "command": "composerMode.agent"
     },
     {
+        "key": "cmd+e",
+        "command": "runCommands",
+        "args": {
+            "commands": [
+                "workbench.action.quickOpenPreviousRecentlyUsedEditor",
+                "workbench.action.acceptSelectedQuickOpenItem"
+            ]
+        }
+    },
+    {
         "key": "cmd+1",
         "command": "workbench.action.focusFirstEditorGroup"
     },


### PR DESCRIPTION
## Background / 背景

`Ctrl+-` (navigateBack) は編集位置の履歴を遡るため、押すたびにさらに前へ進んでしまい、2 ファイル間の往復に使えない。tmux の `prefix Space` (last-window) のように、直前に開いていたファイルへ即座にトグルしたい。

## Changes / 変更内容

`.config/cursor/keybindings.json` に \`cmd+e\` を追加。\`runCommands\` で \`quickOpenPreviousRecentlyUsedEditor\` → \`acceptSelectedQuickOpenItem\` を連続実行することで、押すたびに MRU が確定され、直近 2 ファイル間でトグルする挙動になる。

なお Cursor デフォルトの \`cmd+e\` (\`actions.findWithSelection\`) は上書きされるが、\`cmd+f\` で同等のことができるため実害は少ない。

## Impact scope / 影響範囲

- Cursor (VS Code) のキーバインドのみ
- 他のツール・設定への影響なし

## Testing / 動作確認

- [x] main.rs を開いた状態で lib.rs に切り替え後、\`cmd+e\` で main.rs に戻る
- [x] もう一度 \`cmd+e\` で lib.rs に戻る (2 ファイル間トグル)
- [x] 連打しても履歴を遡り続けるのではなく、トグル動作を維持する

🤖 Generated with [Claude Code](https://claude.com/claude-code)