### PR TITLE
fix(tmux): unbind C-o and M-o to prevent accidental pane rotate

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -25,6 +25,10 @@ bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
+# ペインのローテート (入れ替え) は誤爆しやすいので無効化
+unbind C-o
+unbind M-o
+
 # コピーモードでvimキーバインドを使う
 setw -g mode-keys vi
 


### PR DESCRIPTION
## Background / 背景

\`prefix o\` (select-pane) を打つ際、Ctrl を押しっぱなしのまま \`o\` を打鍵すると \`prefix C-o\` が発動し、ペインがローテート (入れ替え) されてしまう。意図しないペイン配置の変更が発生し、誤爆しやすい。ペインローテート機能は使用していないため無効化する。

## Changes / 変更内容

\`.config/tmux/tmux.conf\` に以下を追加。
- \`unbind C-o\` (rotate-window 上方向)
- \`unbind M-o\` (rotate-window 下方向、同じく誤爆対策)

\`prefix o\` (select-pane) はそのまま動作する。

## Impact scope / 影響範囲

- tmux のキーバインドのみ
- 既存の \`prefix h/j/k/l\` でのペイン移動には影響なし

## Testing / 動作確認

- [x] \`prefix C-o\` を打鍵してもペインがローテートしないことを確認
- [x] \`prefix o\` で次のペインへ移動できることを確認
- [x] \`tmux source-file ~/.config/tmux/tmux.conf\` で設定リロードに成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)