### PR TITLE
chore(git): enable push.autoSetupRemote

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -21,3 +21,5 @@
 	process = git-lfs filter-process
 	required = true
 	clean = git-lfs clean -- %f
+[push]
+	autoSetupRemote = true


### PR DESCRIPTION
## Background / 背景

新しいブランチで初回 \`git push\` を実行する際、\`--set-upstream\` を明示しないとエラーになり、毎回フルコマンドを打ち直す必要がある。\`push.autoSetupRemote\` を有効化することで、初回 push 時に自動的に upstream を設定し、この手間を省く。

## Changes / 変更内容

\`.gitconfig\` に以下を追加。
\`\`\`
[push]
	autoSetupRemote = true
\`\`\`

これにより \`git push\` のみで自動的に \`origin/<current-branch>\` への upstream 設定込み push が実行される。

## Impact scope / 影響範囲

- ローカルの git 全体の push 挙動
- 既存ブランチ (upstream 設定済み) には影響なし
- 新規ブランチの初回 push 体験のみ変わる

## Testing / 動作確認

- [x] \`git config --global push.autoSetupRemote\` で \`true\` が返る
- [x] 新規ブランチを作成し \`git push\` のみで upstream 込み push できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)