### PR TITLE
chore(helix): use relative line numbers

### DIFF
--- a/.config/helix/config.toml
+++ b/.config/helix/config.toml
@@ -1,7 +1,7 @@
 theme = "bogster-custom"
 
 [editor]
-line-number = "absolute"
+line-number = "relative"
 mouse = false
 clipboard-provider = "pasteboard"
 


### PR DESCRIPTION
## Background / 背景

短〜中距離の行移動やオペレーター操作(`d5j` など)で行数を即座に把握しやすくするため、Helix の行番号表示を相対表示に変更する。

## Changes / 変更内容

- `.config/helix/config.toml` の `line-number` を `absolute` から `relative` に変更

## Impact scope / 影響範囲

- Helix エディタの行番号表示のみ
- 他の設定・ツールへの影響なし

## Testing / 動作確認

- [x] Helix を起動して相対行番号が表示されることを確認 / relative 表示の動作確認
- [x] 絶対行ジャンプ (`:42`, `42gg`) が引き続き動作することを確認 / absolute jump の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)