### PR TITLE
feat(karabiner): add cmd single-press IME toggle rule

### DIFF
--- a/.config/karabiner/assets/complex_modifications/personal_hagaspa.json
+++ b/.config/karabiner/assets/complex_modifications/personal_hagaspa.json
@@ -268,6 +268,67 @@
                     ]
                 }
             ]
+        },
+        {
+            "description": "Tap CMD to toggle Kana/Eisuu",
+            "manipulators": [
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "left_command",
+                        "modifiers": {
+                            "optional": ["any"]
+                        }
+                    },
+                    "parameters": {
+                        "basic.to_if_held_down_threshold_milliseconds": 100
+                    },
+                    "to": [
+                        {
+                            "key_code": "left_command",
+                            "lazy": true
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "key_code": "left_command"
+                        }
+                    ],
+                    "to_if_alone": [
+                        {
+                            "key_code": "japanese_eisuu"
+                        }
+                    ]
+                },
+                {
+                    "type": "basic",
+                    "from": {
+                        "key_code": "right_command",
+                        "modifiers": {
+                            "optional": ["any"]
+                        }
+                    },
+                    "parameters": {
+                        "basic.to_if_held_down_threshold_milliseconds": 100
+                    },
+                    "to": [
+                        {
+                            "key_code": "right_command",
+                            "lazy": true
+                        }
+                    ],
+                    "to_if_held_down": [
+                        {
+                            "key_code": "right_command"
+                        }
+                    ],
+                    "to_if_alone": [
+                        {
+                            "key_code": "japanese_kana"
+                        }
+                    ]
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
## Background / 背景

The cmd single-press IME toggle (left_command → eisuu, right_command → kana) was previously imported from Karabiner's online complex_modifications gallery and lived outside this dotfiles repo. This made new-machine setup depend on internet access and gallery import.

cmd 単押しによる IME 切替（左 cmd → 英数、右 cmd → かな）は従来 Karabiner 公式ギャラリーから import したルールに依存しており、dotfiles 管理外だった。新マシンセットアップ時にインターネット経由でのギャラリー import が必要になっていた。

## Changes / 変更内容

- Add the cmd single-press IME toggle rule to `personal_hagaspa.json` so the definition lives in dotfiles
- Description set to `Tap CMD to toggle Kana/Eisuu` to match the English style of existing rules

- `personal_hagaspa.json` に cmd 単押し IME 切替ルールを追記し、定義を dotfiles 配下で管理
- description は既存ルールに合わせて英語表記 `Tap CMD to toggle Kana/Eisuu` に統一

## Impact scope / 影響範囲

- Karabiner-Elements complex_modifications only. No effect on other dotfiles components.
- On a new machine, this rule can be enabled from the local "Personal rules @hagaspa" entry without internet access. UI enable step is still required (Karabiner does not auto-enable asset rules).

- Karabiner-Elements の complex_modifications のみ。他の dotfiles コンポーネントへの影響なし。
- 新マシンでは「Personal rules @hagaspa」からネット接続なしで Enable 可能。UI からの有効化操作は引き続き必要（Karabiner は asset を自動有効化しないため）。

## Testing / 動作確認

- [x] JSON syntax validated with `python3 -m json.tool` / JSON 構文を検証
- [x] Verified the rule works on the current machine (re-enabled from personal_hagaspa entry after removing the gallery-imported one) / 現マシンでギャラリー由来ルールを削除し personal_hagaspa から再有効化、動作確認済み
- [x] Confirmed left cmd tap sends eisuu, right cmd tap sends kana / 左 cmd 単押しで英数、右 cmd 単押しでかなが送信されることを確認