### PR TITLE
feat(mise): manage rust toolchain and rust-analyzer via mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [settings]
-idiomatic_version_file_enable_tools = ["node", "python", "go", "terraform"]
+idiomatic_version_file_enable_tools = ["node", "python", "go", "terraform", "rust"]
 
 [tools]
 node = "lts"
@@ -7,3 +7,5 @@ bun = "latest"
 gcloud = "latest"
 terraform = "latest"
 biome = "latest"
+rust = "latest"
+rust-analyzer = "latest"


### PR DESCRIPTION
## Background / 背景

Rust toolchain (rustc / cargo / rust-analyzer) を rustup 公式インストーラ経由で管理していたが、dotfiles で再現性のある形で管理できるよう mise に移行する。

Rust は `rust-toolchain.toml` でプロジェクト毎にバージョンを固定する慣習があり、CLAUDE.md の brew first / mise 格上げ基準のうち「Per-project version pinning matters」「registry 一級対応」に該当するため mise で管理する。

rust-analyzer は週次リリースで Rust toolchain と独立に最新追従するのが慣例のため、別エントリで管理する。

## Changes / 変更内容

`.mise.toml`:
- `[tools]` に `rust = "latest"` と `rust-analyzer = "latest"` を追加
- `idiomatic_version_file_enable_tools` に `"rust"` を追加し、プロジェクトの `rust-toolchain.toml` を尊重できるようにする

## Impact scope / 影響範囲

- ローカル開発環境のみ。CI には影響なし
- 既存ユーザーは移行手順 (`rustup self uninstall` → `mise install`) が必要
- helix の `languages.toml` は変更不要 (`command = "rust-analyzer"` のままで mise activate 経由の PATH 解決で動作)

### 注意点 / Note

mise の rust プラグインは内部で rustup を使うため、`~/.cargo/bin/rust-analyzer` に rustup proxy の壊れた symlink が作られる場合がある。一度削除すると `mise install` 再実行でも再作成されない。

## Testing / 動作確認

- [x] `rustup self uninstall` で既存の rustup 環境を削除
- [x] `mise install` で rust 1.95.0 / rust-analyzer 2026-05-04 がインストールされること
- [x] `which rust-analyzer` が `~/.local/share/mise/installs/rust-analyzer/2026-05-04/rust-analyzer` を解決すること
- [x] `rustc --version` / `cargo --version` / `rust-analyzer --version` が正常に動作すること
- [x] helix で `.rs` ファイルを開き、LSP が起動して型ヒント等が表示されること