### PR TITLE
feat(ghostty): add cmd+shift+t toggle for background transparency

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -13,3 +13,13 @@ keybind = cmd+shift+d=unbind
 
 # cmd+w での終了を無効化（誤爆対策）
 keybind = cmd+w=unbind
+
+# 透過モード時の不透明度（0.0=完全透明 〜 1.0=不透明）。
+# Web ドキュメントを背面に置きながら参照するとき用。トグル先の値なので 1 未満必須。
+background-opacity = 0.55
+
+# 明示的な背景色を持つセル（helix の ui.background 等）にも opacity を適用
+background-opacity-cells = true
+
+# Cmd+Shift+T で透過⇄不透明をトグル（macOS のみ実装）
+keybind = cmd+shift+t=toggle_background_opacity


### PR DESCRIPTION
## Background / 背景

Web ドキュメントを背面に置きながらターミナルで作業したいケース向けに、ghostty のウィンドウ背景をオンデマンドで透過させる仕組みを導入する。常時透過は視認性を損なうため、ショートカットで不透明⇄透過をトグルできる構成にしたい。

## Changes / 変更内容

- `.config/ghostty/config`
  - `background-opacity = 0.55` を追加（透過モード時の不透明度）
  - `background-opacity-cells = true` を追加し、helix 等の `ui.background` を持つ TUI も透過対象に含める
  - `keybind = cmd+shift+t=toggle_background_opacity` を追加して透過⇄不透明をトグル

## Impact scope / 影響範囲

- ghostty の見た目のみ。シェル機能や他 dotfiles への影響なし。
- `background-opacity-cells = true` により、helix 含む全 TUI のセル背景（選択ハイライト・カーソル行・diff マーカー等）も同じ opacity で透けるようになる。
- 値の変更（`background-opacity` 自体）は ghostty の再起動が必要だが、トグルはランタイムで動作する。
- macOS のみで `toggle_background_opacity` が動作する点は ghostty 仕様（このリポジトリは macOS 前提のため問題なし）。

## Testing / 動作確認

- [x] `Cmd+Shift+T` で透過⇄不透明がトグルできる
- [x] 透過モードでも helix の bogster テーマの背景が維持されたまま透過する
- [x] 既存の他 keybind（`cmd+d` / `cmd+shift+d` / `cmd+w` の unbind）と衝突しない