### PR TITLE
feat(zsh): include dotfiles in tab completion

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,6 @@
 # Completions
 autoload -Uz compinit && compinit -C
+_comp_options+=(globdots)
 zstyle ":completion:*:commands" rehash 1
 zstyle ':completion:*' menu select=2
 zstyle ':completion:*' matcher-list \


### PR DESCRIPTION
## Background / 背景

`hx <TAB>` のように zsh で補完を実行した際、`.github` や `.config` などの隠しファイル/ディレクトリが補完候補に表示されなかった。zsh のデフォルトでは `.` から始まるファイルを補完対象から除外するため。

## Changes / 変更内容

`.zshrc` の `compinit` 直後に `_comp_options+=(globdots)` を追加。補完時のみ `globdots` 相当を有効化し、通常のグロブ展開（`*` 等）には影響しない。

`setopt globdots` ではなく `_comp_options` に追加する方式を選択することで、スクリプト中の `*` が `.git` 等にマッチする副作用を回避している。

## Impact scope / 影響範囲

- 対話シェルでのタブ補完挙動のみ変更
- スクリプトや非対話セッションでのグロブ展開には影響なし

## Testing / 動作確認

- [x] `source ~/.zshrc` 後、`hx <TAB>` で `.github` `.config` `.zshrc` 等が候補に出ることを確認
- [x] `echo *` の出力にドットファイルが含まれないことを確認（globdots が glob 全体に影響していない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)