### PR TITLE
feat(karabiner): add home row mods for Opt+Shift on semicolon

### DIFF
--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -249,6 +249,40 @@
             ]
           },
           {
+            "description": "Home Row Mods (Opt+Shift on ;)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "semicolon",
+                  "modifiers": {
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "right_option",
+                    "modifiers": [
+                      "right_shift"
+                    ],
+                    "lazy": true
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "semicolon"
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_alone_timeout_milliseconds": 200,
+                  "basic.to_if_held_down_threshold_milliseconds": 200
+                }
+              }
+            ]
+          },
+          {
             "description": "Tap CMD to toggle Kana/Eisuu",
             "manipulators": [
               {

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -58,6 +58,20 @@ writeToProfile('Default profile', [
     ),
   ]),
 
+  rule('Home Row Mods (Opt+Shift on ;)').manipulators([
+    map({ key_code: 'semicolon', modifiers: { optional: ['any'] } })
+      .to({
+        key_code: 'right_option',
+        modifiers: ['right_shift'],
+        lazy: true,
+      })
+      .toIfAlone({ key_code: 'semicolon' })
+      .parameters({
+        'basic.to_if_alone_timeout_milliseconds': 200,
+        'basic.to_if_held_down_threshold_milliseconds': 200,
+      }),
+  ]),
+
   rule('Tap CMD to toggle Kana/Eisuu').manipulators([
     withMapper({
       left_command: 'japanese_eisuu',


### PR DESCRIPTION
## Background / 背景

US 配列で Raycast の `⌥⇧X` 系ホットキーを多用しているが、物理 Option キーは右下隅でホームポジションから遠く、右手をスライドさせる必要があった。Home Row Mods (HRM) を導入して `;` 長押しで Opt+Shift を送れるようにし、ホームポジションを維持したままホットキーを発火できるようにする。

## Changes / 変更内容

`karabiner.ts` に Home Row Mods ルールを追加:

- `;` 単押し → 通常通り `;` 文字
- `;` 長押し（200ms 以上） + 文字 → `⌥⇧+文字` を送信
- 実装は `to.modifiers` で Shift を Option に重ねる lazy hold 方式（複数 lazy `to` の並列は Karabiner で期待通り動かなかったため）

## Impact scope / 影響範囲

- Karabiner-Elements の Complex Modifications に新ルールが 1 つ追加される
- 既存の Ctrl tap-hold / Cmd→英数かな / Ctrl ナビゲーション系ルールとは独立で衝突なし
- Raycast 側設定は元の `⌥⇧X` のまま変更不要
- `;` を含む文章打鍵への影響: 単押しは通常動作するので影響なし

## キー選定理由

| キー | 衝突 | 備考 |
|------|------|------|
| `s` | ★★★ 最悪 | sa/si/su/se/so 全衝突（JP ローマ字） |
| `f` | ★ | fa/fu 少なめだが Step2 の Shift 化と被る |
| `a` | ★★ | 母音、ai/an 衝突 |
| `;` | ☆ ほぼゼロ | 文章中にまず出ない |

`;` を採用。Shift を重ねることで Helix の `A-s` (split selection on newline) 等の plain Alt+letter バインドとも競合しない。

## Testing / 動作確認

- [x] `;` 単押しで `;` が出る
- [x] `;` 長押し + `c` で Cursor が起動（`⌥⇧C`）
- [x] `;` 長押し + `s` で Slack が起動（`⌥⇧S`）
- [x] 通常の英文・JP ローマ字打鍵に支障なし
- [x] 物理 Option キーで Helix `A-s` が従来通り動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)