### PR TITLE
feat(zsh): exclude "/" from WORDCHARS for path-aware word kill

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -16,6 +16,9 @@ source <(fzf --zsh)
 
 LISTMAX=1000
 
+# Opt+delete / Opt+d がパスを 1 セグメントずつ削除するよう "/" を境界に戻す
+WORDCHARS='*?_-.[]~=&;!#$%^(){}<>'
+
 unsetopt beep
 
 # App Config


### PR DESCRIPTION
## Background / 背景

ghostty で `Ctrl+W` を押すと `~` が表示され、カーソル前の単語削除ができない問題を調査した。原因は Karabiner の Ctrl navigation ルールで `Ctrl+W` → Page Up にグローバルリマップされており、ターミナルではエスケープシーケンス `\e[5~` の末尾 `~` が残るため。

Karabiner ルールは `Ctrl+H/J/K/L` の矢印用途で全アプリ有効にしたいので、ターミナル側で代替手段を整える方針とした。`Opt+delete` / `Opt+d` は zsh が `backward-kill-word` / `kill-word` にデフォルトでバインド済み、`macos-option-as-alt = true` 設定済みのため即利用可能。

ただし zsh デフォルトの `WORDCHARS` には `/` が含まれており、長いファイルパスが一発で全削除されてしまう。atuin / 補完で展開されたパスの末尾だけ修正したいユースケースに合わない。

## Changes / 変更内容

- `.zshrc` に `WORDCHARS` を追加し、デフォルトから `/` を除外
- これにより `Opt+delete` / `Opt+d` / `Opt+b` / `Opt+f` がパスを 1 セグメント単位で扱うようになる

## Impact scope / 影響範囲

- zsh の単語境界判定全般。`/` を境界として扱うようになるため、パス操作系のキーバインドの粒度が変わる
- 他の単語境界文字 (空白、`=`、`-` など) の挙動は不変

## Testing / 動作確認

- [x] `source ~/.zshrc` 後、長いパスを入力 → `Opt+delete` で末尾セグメントのみ削除されることを確認
- [x] `Opt+d` でカーソル右の 1 セグメントが削除されることを確認
- [x] `Opt+b` / `Opt+f` でセグメント間ジャンプが効くことを確認
- [x] スペース区切りの通常コマンドラインで `Opt+delete` が単語単位で動作することを確認