### PR TITLE
feat(tmux): switch prefix to Ctrl+Space and tune HRM

### DIFF
--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -301,7 +301,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -328,7 +328,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -355,7 +355,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -382,7 +382,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -409,7 +409,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -436,7 +436,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -463,7 +463,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -490,7 +490,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -517,7 +517,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -544,7 +544,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -571,7 +571,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -598,7 +598,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -625,7 +625,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -652,7 +652,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -679,7 +679,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -706,7 +706,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -733,7 +733,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -760,7 +760,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -787,7 +787,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -814,7 +814,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -841,7 +841,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -868,7 +868,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -895,7 +895,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -922,7 +922,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -949,7 +949,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -976,7 +976,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1003,7 +1003,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1030,7 +1030,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1057,7 +1057,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1084,7 +1084,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1111,7 +1111,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1138,7 +1138,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1165,7 +1165,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1192,7 +1192,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1219,7 +1219,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1246,7 +1246,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1273,7 +1273,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1300,7 +1300,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1327,7 +1327,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1354,7 +1354,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1381,7 +1381,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1408,7 +1408,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1435,7 +1435,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1462,7 +1462,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1489,7 +1489,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1516,7 +1516,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1543,7 +1543,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1570,7 +1570,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1597,7 +1597,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1624,7 +1624,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1651,7 +1651,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1678,7 +1678,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1705,7 +1705,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1732,7 +1732,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1759,7 +1759,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1786,7 +1786,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1813,7 +1813,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1840,7 +1840,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1893,7 +1893,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1920,7 +1920,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1947,7 +1947,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -1974,7 +1974,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2001,7 +2001,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2028,7 +2028,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2055,7 +2055,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2082,7 +2082,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2109,7 +2109,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2136,7 +2136,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2163,7 +2163,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2190,7 +2190,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2217,7 +2217,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2244,7 +2244,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2271,7 +2271,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2298,7 +2298,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2325,7 +2325,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2352,7 +2352,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2379,7 +2379,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2406,7 +2406,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2433,7 +2433,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2460,7 +2460,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2487,7 +2487,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2514,7 +2514,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2541,7 +2541,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2568,7 +2568,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2595,7 +2595,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2622,7 +2622,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2649,7 +2649,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2676,7 +2676,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2703,7 +2703,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2730,7 +2730,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2757,7 +2757,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2784,7 +2784,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2811,7 +2811,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2838,7 +2838,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2865,7 +2865,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2892,7 +2892,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2919,7 +2919,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2946,7 +2946,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -2973,7 +2973,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3000,7 +3000,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3027,7 +3027,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3054,7 +3054,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3081,7 +3081,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3108,7 +3108,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3135,7 +3135,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3162,7 +3162,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3189,7 +3189,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3216,7 +3216,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3243,7 +3243,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3270,7 +3270,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3297,7 +3297,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3324,7 +3324,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3351,7 +3351,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3378,7 +3378,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3405,7 +3405,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3432,7 +3432,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3485,7 +3485,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3512,7 +3512,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3539,7 +3539,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3566,7 +3566,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3593,7 +3593,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3620,7 +3620,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3647,7 +3647,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3674,7 +3674,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3701,7 +3701,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3728,7 +3728,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3755,7 +3755,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3782,7 +3782,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3809,7 +3809,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3836,7 +3836,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3863,7 +3863,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3890,7 +3890,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3917,7 +3917,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3944,7 +3944,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3971,7 +3971,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -3998,7 +3998,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4025,7 +4025,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4052,7 +4052,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4079,7 +4079,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4106,7 +4106,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4133,7 +4133,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4160,7 +4160,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4187,7 +4187,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4214,7 +4214,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4241,7 +4241,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4268,7 +4268,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4295,7 +4295,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4322,7 +4322,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4349,7 +4349,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4376,7 +4376,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4403,7 +4403,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4430,7 +4430,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4457,7 +4457,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4484,7 +4484,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4511,7 +4511,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4538,7 +4538,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4565,7 +4565,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4592,7 +4592,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4619,7 +4619,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4646,7 +4646,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4673,7 +4673,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4700,7 +4700,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4727,7 +4727,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4754,7 +4754,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4781,7 +4781,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4808,7 +4808,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4835,7 +4835,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4862,7 +4862,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4889,7 +4889,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4916,7 +4916,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4943,7 +4943,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4970,7 +4970,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -4997,7 +4997,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5024,7 +5024,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5082,7 +5082,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5123,7 +5123,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5164,7 +5164,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5205,7 +5205,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5246,7 +5246,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5287,7 +5287,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5328,7 +5328,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5369,7 +5369,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5410,7 +5410,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5451,7 +5451,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5492,7 +5492,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5533,7 +5533,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5574,7 +5574,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5615,7 +5615,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5656,7 +5656,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5697,7 +5697,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5738,7 +5738,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5779,7 +5779,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5820,7 +5820,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5861,7 +5861,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5902,7 +5902,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5943,7 +5943,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -5984,7 +5984,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6025,7 +6025,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6066,7 +6066,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6107,7 +6107,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6148,7 +6148,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6189,7 +6189,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6230,7 +6230,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6271,7 +6271,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6312,7 +6312,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6353,7 +6353,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6394,7 +6394,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6435,7 +6435,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6476,7 +6476,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6517,7 +6517,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6558,7 +6558,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6599,7 +6599,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6640,7 +6640,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6681,7 +6681,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6722,7 +6722,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6763,7 +6763,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6804,7 +6804,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6845,7 +6845,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6886,7 +6886,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6927,7 +6927,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -6968,7 +6968,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7009,7 +7009,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7050,7 +7050,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7091,7 +7091,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7132,7 +7132,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7173,7 +7173,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7214,7 +7214,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7255,7 +7255,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7296,7 +7296,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7337,7 +7337,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7378,7 +7378,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {
@@ -7419,7 +7419,7 @@
                   }
                 },
                 "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 90
+                  "basic.simultaneous_threshold_milliseconds": 180
                 },
                 "to": [
                   {

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -42,7 +42,7 @@ const HRM_PARAMS = {
   'basic.to_if_alone_timeout_milliseconds': 200,
   'basic.to_if_held_down_threshold_milliseconds': 200,
 } as const;
-const HRM_SIMULTANEOUS_MS = 90;
+const HRM_SIMULTANEOUS_MS = 180;
 
 // Letter rolls (e.g. "sa", "si") within HRM_SIMULTANEOUS_MS pass through as literals
 // instead of triggering the modifier — works around Karabiner's lack of QMK-style

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -1,6 +1,13 @@
 # tmux起動時のシェルをzshにする
 set -g default-shell /bin/zsh
 
+# Prefix を Ctrl+Space に変更
+# Karabiner の HRM (D=Ctrl) と組み合わせて、左 D ホールド + 右 thumb Space の
+# bilateral chord で打鍵する想定。Ctrl+B は左 D + 左 B で同手チョードになり打ちにくいため。
+unbind C-b
+set -g prefix C-Space
+bind C-Space send-prefix
+
 # シェルの環境変数をセッション作成時に取り込む
 set -g update-environment "EDITOR VISUAL"
 # yazi がターミナル種別を正しく検出するために必要

--- a/settings.sh
+++ b/settings.sh
@@ -16,6 +16,14 @@ defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
 defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true
 defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 
+# Free up Ctrl+Space for tmux prefix by disabling "Select the previous input source"
+# (AppleSymbolicHotKeys id 60). Requires logout/login or `activateSettings -u` to apply.
+# NOTE: On macOS Tahoe (26+) this plist write often fails to propagate to the runtime;
+# if Ctrl+Space still switches input sources, manually uncheck via:
+#   System Settings → Keyboard → Keyboard Shortcuts → Input Sources → "Select the previous input source"
+defaults write com.apple.symbolichotkeys.plist AppleSymbolicHotKeys -dict-add 60 \
+  '{enabled = 0; value = { parameters = (32, 49, 262144); type = "standard"; }; }'
+
 echo "macOS settings applied. Please restart your system for all changes to take effect."
 echo ""
 echo -e "\033[1;33m⚠️  RESTART REQUIRED\033[0m"


### PR DESCRIPTION
## Background / 背景

#113 で Home Row Mods (F/S/D/J) を導入した直後の運用で 2 件のフォローアップ:

1. **tmux prefix `Ctrl+B` が打ちにくくなった**: D HRM を Ctrl にしたことで、Ctrl+B は左 D + 左 B の同手チョードになり simultaneous safety と衝突して prefix 起動が不安定
2. **ローマ字 "si" / "su" / "sa" が依然 misfire**: simultaneous safety の閾値 90ms がユーザーの打鍵速度より速く、catch しきれていなかった

## Changes / 変更内容

### 1. tmux prefix を `Ctrl+Space` に変更 (`feat(tmux)`)

- `tmux.conf`: `unbind C-b` + `set -g prefix C-Space` + `bind C-Space send-prefix`
- `settings.sh`: macOS の AppleSymbolicHotKeys id 60 (Select the previous input source = `Ctrl+Space` 標準割当) を無効化する `defaults write` を追加
- macOS Tahoe (26+) ではこの plist 書き込みが GUI/runtime まで反映されないケースがあり、その場合は手動で System Settings から外す必要がある旨をコメントで明記

`Ctrl+Space` は D HRM (左 middle) + Space (親指) の bilateral chord。さらに Space は letter safety 対象外なので simultaneous safety にかからず即発火する。

### 2. HRM simultaneous 閾値を 90ms → 180ms に拡張 (`chore(karabiner)`)

- `karabiner.ts`: `HRM_SIMULTANEOUS_MS = 90` → `180`
- 60-80wpm 程度のローマ字入力 (si / su / sa 等) の打鍵間隔を確実にカバー
- トレードオフ: 意図的な HRM modifier + letter は HRM キー押下から letter 押下まで 180ms 以上空ける運用に

## Impact scope / 影響範囲

- **tmux**: prefix キーが変わるが、`prefix + h/j/k/l` (ペイン移動)、`prefix + Space` (last-window) 等の既存 binding は全て従来通り動作
- **macOS**: `Ctrl+Space` で「前の入力ソース選択」が無効化される (ユーザーは英数/かな切替を Karabiner の左右 Cmd 単押しで行っているため実害なし)
- **Karabiner**: HRM 閾値以外の構造変更なし。F Shift, S Opt, D Ctrl, J Shift, `;` Opt+Shift の役割割当は維持
- 他 dotfiles, シェル, アプリ設定への影響なし

## Testing / 動作確認

- [x] tmux で `Ctrl+Space` を押すと prefix が起動 (System Settings GUI 経由で「前の入力ソースを選択」を外した状態で確認)
- [x] `prefix + h/j/k/l` でペイン移動が継続動作
- [x] `prefix + Space` で last-window が継続動作
- [x] D HRM (左 middle ホールド + Space タップ) で `Ctrl+Space` 発火 — overlap タイミングは要慣れ
- [x] ローマ字 "si" / "su" / "sa" を普段の速度で連打して misfire しないことを確認 (180ms 閾値)
- [x] 同手ロール (sa / dw / fr 等) も継続して literal 出力されることを確認
- [x] 物理 Ctrl + Space でも prefix 起動 (HRM バイパス時の動作)

🤖 Generated with [Claude Code](https://claude.com/claude-code)