### PR TITLE
chore(claude): bump effort level to max

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -107,6 +107,6 @@
     "rust-analyzer-lsp@claude-plugins-official": true
   },
   "language": "Japanese",
-  "effortLevel": "high",
+  "effortLevel": "max",
   "showThinkingSummary": true
 }


### PR DESCRIPTION
## Background / 背景

Claude Code の `effortLevel` を `high` から `max` に引き上げる。より深い推論を行わせたい。

## Changes / 変更内容

- `.config/claude/settings.json` の `effortLevel` を `high` → `max` に変更

## Impact scope / 影響範囲

- Claude Code の応答時の thinking budget が拡大
- ローカル開発環境のみ（CI/他ツールへの影響なし）

## Testing / 動作確認

- [x] `./link.sh` で symlink 済みの `~/.claude/settings.json` 経由で反映されること / Settings reflected via symlink
- [x] JSON 構文が壊れていないこと / JSON syntax validated