### PR TITLE
chore(git): enable fetch.prune to auto-remove stale remote refs

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -23,3 +23,5 @@
 	clean = git-lfs clean -- %f
 [push]
 	autoSetupRemote = true
+[fetch]
+	prune = true


### PR DESCRIPTION
## Background / 背景

`git fetch` 単体では削除済みリモートブランチに対応する `origin/*` の remote-tracking ref を消さないため、ローカルの `[gone]` マーカーが古くなり、`clean_gone` がリモート削除済みブランチを取りこぼすことがあった。`fetch --prune` を毎回手動で打つ運用は形骸化しやすい。

## Changes / 変更内容

`.gitconfig` に `[fetch] prune = true` を追加。`git fetch` / `git pull` のたびに自動で `--prune` 相当が走るようにする。

## Impact scope / 影響範囲

- グローバル `~/.gitconfig`（dotfiles の symlink 経由で全リポジトリに適用）
- 既存リポジトリの remote-tracking ref が次回 fetch 時に最新化される
- `[gone]` マーカーが常に最新になり、`clean_gone` スキルの精度が向上
- リモート一時不通時に fetch すると stale ref が消えるが、復旧後に再 fetch すれば戻るため実害なし

## Testing / 動作確認

- [x] `git config --get fetch.prune` が `true` を返すこと
- [x] `.gitconfig` シンタックスが壊れていないこと（`git config --list` がエラーを出さない）