### PR TITLE
feat(karabiner): add HRM cheatsheet with tmux popup viewer

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -1,0 +1,48 @@
+# Home Row Mods (HRM) Cheatsheet
+
+source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/tmux/tmux.conf`
+
+## Modifier mappings
+
+| Key             | Hold → Modifier | Scope                                 |
+| --------------- | --------------- | ------------------------------------- |
+| F (left index)  | Shift           | All apps                              |
+| S (left ring)   | Option          | All apps                              |
+| D (left middle) | Control         | All apps                              |
+| J (right index) | Shift           | All except Helix / Terminal / Chrome  |
+| ; (right pinky) | Opt + Shift     | All apps                              |
+
+- A pinky には HRM を載せない (左手首腱鞘炎対策)
+- Cmd は物理キーのまま (HRM 化しない)
+
+## Cmd tap → IME
+
+| Key       | Tap          | Hold |
+| --------- | ------------ | ---- |
+| Left Cmd  | 英数 (eisuu) | Cmd  |
+| Right Cmd | かな (kana)  | Cmd  |
+
+## Ctrl navigation (D ホールドで発火)
+
+| Combo                     | Action                                       |
+| ------------------------- | -------------------------------------------- |
+| Ctrl + h / j / k / l      | ← / ↓ / ↑ / →                                |
+| Ctrl + , / .              | Option + ← / →  (word jump)                  |
+| Ctrl + w                  | Page Up                                      |
+| Ctrl + v                  | Page Down                                    |
+| Ctrl + b  (terminal)      | 英数 → Ctrl+b  (tmux prefix の前に IME 抜け) |
+| Ctrl + g  (zsh)           | clear-screen  (Ctrl+L が → に潰れる代替)     |
+| Ctrl + P, Ctrl + O  (zsh) | 現在行を pbcopy                              |
+
+## tmux prefix
+
+`Ctrl + Space` = D (Ctrl) + 右親指 Space の bilateral chord。
+Ctrl+B は左 D + 左 B の同手チョードで打ちにくいため変更。
+
+## Timing
+
+- `to_if_alone_timeout`: 200ms
+- `to_if_held_down_threshold`: 200ms
+- bilateral roll window: 180ms (この時間内の反対側ロールはリテラル扱い)
+
+意図的な modifier + letter は 180ms より長く HRM キーをホールドしてから他キーを叩く。

--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -62,6 +62,11 @@ bind c new-window -c '#{pane_current_path}'
 # https://github.com/sxyazi/yazi/issues/2308#issuecomment-2731102243
 bind y run-shell -b 'tmux display-popup -d "#{pane_current_path}" -w 80% -h 80% -E "bash ~/.config/helix/yazi-picker.sh #{pane_id}"'
 
+# HRM (Home Row Mods) チートシートを popup で開く
+# 既定の `m` (select-pane -m / mark-pane) は使わないので上書き
+unbind m
+bind m display-popup -w 80% -h 80% -E "bat --style=plain --color=always --paging=always ~/.config/karabiner/HRM.md"
+
 # エスケープシーケンスの待機時間を0にする（キー入力の応答性向上）
 set -sg escape-time 0
 

--- a/.config/zsh/command.sh
+++ b/.config/zsh/command.sh
@@ -17,3 +17,8 @@ gbm() {
   : "${branch:=main}"
   git switch "$branch" && git pull
 }
+
+# Home Row Mods cheatsheet. tmux からは prefix + m の popup でも開ける。
+hrm() {
+  bat --style=plain --color=always --paging=always ~/.config/karabiner/HRM.md
+}

--- a/link.sh
+++ b/link.sh
@@ -13,6 +13,7 @@ entries=(
   .config/helix/languages.toml
   .config/helix/themes/bogster-custom.toml
   .config/helix/yazi-picker.sh
+  .config/karabiner/HRM.md
   .config/karabiner/karabiner.json
   .config/sheldon/plugins.toml
   .config/yazi/init.lua


### PR DESCRIPTION
## Background / 背景

Home Row Mods (HRM) のキーマッピング (F/S/D/J/`;`)、Cmd tap、Ctrl ナビゲーション、タイミングパラメータ等が `karabiner.ts` に分散しており、ふと確認したいときに参照しづらかった。

## Changes / 変更内容

- `.config/karabiner/HRM.md` を新規作成 (HRM 一覧、Cmd tap、Ctrl ナビ、tmux prefix、HRM タイミングを集約)
- `.config/zsh/command.sh` に `hrm` 関数を追加 (シェルから直接表示)
- `.config/tmux/tmux.conf` で `prefix + m` を popup 表示にバインド (デフォルトの `select-pane -m` を上書き — 使っていないため)
- `link.sh` の `entries` に `HRM.md` を追加

## Impact scope / 影響範囲

- tmux: `prefix + m` の挙動が `select-pane -m` (mark-pane) から HRM popup 表示に変わる。mark-pane / `M-pane swap` ワークフローを使っている場合は影響あり (現状未使用)
- zsh: `hrm` 関数が新規追加。既存コマンドへの影響なし
- karabiner: 設定変更なし (ドキュメント追加のみ)

## Testing / 動作確認

- [x] `./link.sh` で `~/.config/karabiner/HRM.md` の symlink が作成されることを確認
- [x] `tmux source-file ~/.tmux.conf` 後、`prefix + m` で popup が開きチートシートが表示されることを確認
- [x] popup 内で `q` を押すと閉じることを確認
- [x] `bat --style=plain --color=always --paging=never ~/.config/karabiner/HRM.md` でレンダリング確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)