### PR TITLE
chore(claude): fix effortLevel to xhigh and enable auto mode

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -46,9 +46,6 @@
       "mcp__claude_ai_Notion__notion-query-meeting-notes",
       "mcp__claude_ai_Notion__notion-search"
     ],
-    "additionalDirectories": [
-      "~/Desktop"
-    ],
     "deny": [
       "Bash(helm upgrade*)",
       "Bash(helm install*)",
@@ -60,7 +57,11 @@
       "Bash(kubectl patch:*)",
       "Bash(kubectl scale:*)",
       "Bash(kubectl rollout:*)"
-    ]
+    ],
+    "additionalDirectories": [
+      "~/Desktop"
+    ],
+    "defaultMode": "auto"
   },
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
@@ -107,6 +108,7 @@
     "rust-analyzer-lsp@claude-plugins-official": true
   },
   "language": "Japanese",
-  "effortLevel": "max",
-  "showThinkingSummary": true
+  "effortLevel": "xhigh",
+  "showThinkingSummary": true,
+  "skipAutoPermissionPrompt": true
 }


### PR DESCRIPTION
## Background / 背景

Claude Code の設定変更が `settings.json` に自動で書き戻された際、意図しない差分が発生していた。あわせて、直近のコミット (#116) で設定していた `effortLevel: max` が無効値（`max` は未対応）であったことが判明した。

## Changes / 変更内容

- `effortLevel` を無効値 `max` から有効な最大値 `xhigh` に修正
- `defaultMode` を `auto`（自動許可モード）に設定
- `skipAutoPermissionPrompt` を有効化
- `additionalDirectories` のキー位置が自動書き戻しで移動（実質変更なし）

## Impact scope / 影響範囲

`~/.claude/settings.json`（dotfiles 管理対象）のみ。Claude Code の挙動（effort レベル・パーミッションモード）に影響する。

## Testing / 動作確認

- [x] `settings.json` が有効な JSON であること
- [x] `effortLevel` の有効値が `low/medium/high/xhigh` であることを確認し `xhigh` に修正