### PR TITLE
docs(karabiner): add HRM shared-secret troubleshooting

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -46,3 +46,20 @@ Ctrl+B は左 D + 左 B の同手チョードで打ちにくいため変更。
 - bilateral roll window: 180ms (この時間内の反対側ロールはリテラル扱い)
 
 意図的な modifier + letter は 180ms より長く HRM キーをホールドしてから他キーを叩く。
+
+## Troubleshooting
+
+### 「設定は正しいのに特定キーだけ挙動が古い」(例: helix で j だけ単発になりリピートしない)
+
+`karabiner.json` は正しいのに、実機では古いルールセットで動いている状態。Karabiner のデーモン(core_service)と user プロセスの認証 (shared secret) が食い違うと、設定リロードが grabber/デーモンに伝わらず発生する。
+
+切り分けの決め手: `j` だけ単発で `h/k/l` はリピートする場合、`J→Shift` tap-hold (`unlessVimApp` で除外済みのはず) が live で生きている = 設定が反映されていない証拠。
+
+```bash
+# 1. shared secret エラーが連続発生しているか確認
+tail /var/log/karabiner/core_service.log   # "invalid shared secret" が約0.5秒おきに出ていれば該当
+```
+
+2. メニューバーから Karabiner-Elements を Quit → 再起動（最小侵襲）。ダメなら macOS 再起動で DriverKit デーモンまで再同期。
+3. 復旧サインは同ログの `Load .../karabiner.json...` → `core_configuration is updated.` → `verified peer connected`。
+4. この症状では `karabiner.ts` は触らない（設計は正しい。原因は Karabiner の状態異常）。


### PR DESCRIPTION
## Background / 背景

helix (ghostty 上) で `j` だけ連続入力できず単発になる事象が発生した。`karabiner.json` 上は `J→Shift` HRM が ghostty を含む端末で除外済みだったが、実機では除外前の古いルールセットで動いていた。原因は Karabiner のデーモン(core_service)と user プロセスの shared secret 不整合で、`core_service.log` に `invalid shared secret` が連続出力されていた。Karabiner 再起動で解消したため、同じ症状に再度遭遇したとき素早く辿れるよう手順を残す。

## Changes / 変更内容

- `.config/karabiner/HRM.md` に Troubleshooting セクションを追記
  - 症状（特定キーだけ挙動が古い／j だけ単発・h/k/l はリピート）と切り分けの決め手
  - `core_service.log` で `invalid shared secret` を確認するコマンド
  - Karabiner 再起動 →（ダメなら）macOS 再起動の手順
  - 復旧サインのログ行
  - `karabiner.ts` は触らない旨（設計は正しく、Karabiner の状態異常が原因）

## Impact scope / 影響範囲

ドキュメントのみ。キーマップ設定 (`karabiner.ts` / `karabiner.json`) や挙動への変更はなし。

## Testing / 動作確認

- [x] HRM.md の追記内容を確認 / Markdown 整形を確認
- [x] 記載手順は実際の事象で再起動により解消済み（ログの `verified peer connected` 回復を確認）