### PR TITLE
docs(terminal): add cmux migration decision and refresh workflow

### DIFF
--- a/docs/cmux-vs-tmux.md
+++ b/docs/cmux-vs-tmux.md
@@ -1,0 +1,77 @@
+# cmux 移行検討結果 (2026-06)
+
+iterm + tmux から cmux に移行した友人をきっかけに、現在の ghostty + tmux 環境を cmux に乗り換える価値があるかを検討した結果。**結論: 当面 cmux に移行しない。ghostty + tmux を継続する。**
+
+## 背景
+
+- ターミナルに求める要件は **「軽い」「キーボードのみで操作できる」** の 2 点
+- 現状は **ghostty（ターミナルエミュレータ）+ tmux（多重化）** の構成
+- tmux は prefix を `Ctrl+Space` に変更し、HRM・vim キーバインド・resurrect/continuum・yazi popup 連携などかなり作り込んでいる（→ [terminal-workflow.md](terminal-workflow.md)）
+- 友人が「iterm + tmux → cmux」へ移行したため、同じ価値が自分にもあるかを確認
+
+## cmux とは
+
+「cmux」は同名プロジェクトが複数あるため注意。今回の文脈（iterm + tmux からの移行）に合致するのは **manaflow-ai/cmux**（2026-02 リリース）。
+
+| 名前 | 正体 | 今回との関連 |
+|---|---|---|
+| **manaflow-ai/cmux** | AI コーディングエージェント向け macOS ネイティブターミナル | ✅ これが検討対象 |
+| soheilhy/cmux | Go の接続マルチプレクサ（同一ポートで gRPC/HTTP 等を多重化） | ❌ 無関係 |
+| craigsc/cmux | Claude Code 用 git worktree ライフサイクル管理ツール | △ 用途次第で別途検討余地 |
+
+manaflow-ai/cmux の特徴:
+
+- **主目的は「複数の AI コーディングエージェント（Claude Code, Codex 等）を並列で回す」こと**。公式も *"The terminal built for coding agents, multitasking"* / *"specifically targeted towards people who use a ton of terminal-based agentic workflows"* と明言
+- 中核機能: vertical tabs サイドバー（git ブランチ・PR ステータス・ポート・通知を表示）、エージェント hook 連携の通知システム（OSC 9/99/777 + `cmux notify` CLI）、split panes、embedded browser、socket API、session restore
+- 技術: **Swift + AppKit ネイティブ（Electron 不使用）+ libghostty**。これは ghostty とまったく同じレンダリングエンジン
+- インストール: `brew tap manaflow-ai/cmux && brew install --cask cmux`（ghostty config を読み込むのでテーマ/フォントは流用される）
+
+## 結論
+
+要件 2 点に対する評価:
+
+| 要件 | cmux の実力 | 評価 |
+|---|---|---|
+| **軽い** | native Swift + libghostty で *"Fast startup, low memory"*。Warp 等の Electron 系より軽い | △ 既に libghostty 本体（ghostty）を使用中。cmux は embedded browser・通知システム等を載せる分、**ghostty 単体より軽くはならない**（機能増で重い方向） |
+| **キーボードのみ** | `⌘N/⌘T/⌘D` 等のショートカット豊富、prefix キー不要 | △ 操作自体は可能だが vertical tabs・notification rings・embedded browser など **GUI 前提の「ハイブリッド設計」**。完全キーボード完結を狙う tmux とは思想が異なる |
+
+→ **「軽い」「キーボードのみ」のどちらも cmux の差別化ポイントではない。** cmux の旨味は AI エージェント並列管理であり、その用途を抜くと移行の動機が消える。友人の移行はおそらくエージェント並列ワークフローを持っているためで、要件が異なる。
+
+## 移行コスト（失うもの）
+
+現状の tmux 資産は cmux に引き継げない:
+
+| 失う機能 | 内容 | cmux での扱い |
+|---|---|---|
+| HRM 連携の prefix 設計 | `Ctrl+Space` を「左手 D=Ctrl ホールド + 右親指 Space」の bilateral chord で打つ（左手首腱鞘炎対策の核） | ❌ `⌘` ベースショートカットで別物。再設計が必要 |
+| tmux-resurrect + continuum | プロセス込みのセッション自動保存/復元 | ❌ cmux の session restore は **UI レイアウトのみ**。*"tmux, vim, shells reopen as normal terminals"* と明記 |
+| detach / reattach | SSH 切断後もセッション存続・別マシンから再アタッチ | ❌ **cmux には存在しない**。リモート作業では結局 tmux 併用が必要 |
+| vim キーバインド移動 / yazi・HRM popup 連携 | tmux.conf で作り込み済み | ❌ 作り直し |
+
+調査ソースが口を揃えるのは、**cmux と tmux は「代替」ではなく「補完」** だという点。乗り換えても tmux は手放せない。
+
+## 学び
+
+- **ツールの「主目的（誰向けか）」を要件と突き合わせる。** cmux はベンチマーク的な「軽さ・速さ」は満たすが、本質は AI エージェントオーケストレーション。自分の要件（軽い・キーボード）はその副次的性質にすぎず、移行の決め手にならない
+- **同じレンダリングエンジン（libghostty）でも、上に載る機能量で「軽さ」は変わる。** ghostty 単体 < cmux（embedded browser 等を内包）
+- **「友人が移行した」は移行理由にならない。** 友人と自分でワークフロー（エージェント並列の有無）が違えば、最適なツールも違う
+
+## 再検討のトリガー
+
+以下が発生したら再検討する:
+
+- **Claude Code / Codex を複数 worktree で同時に走らせて並列オーケストレーションしたくなったとき** → cmux 本体、または worktree 特化の craigsc/cmux が刺さる
+- 逆に言えば、そのニーズが無いうちは移行不要
+
+## 関連
+
+- [terminal-workflow.md](terminal-workflow.md) — 現状の ghostty + tmux ワークフロー（移行で失う資産の一覧でもある）
+- [karabiner-vs-nix.md](karabiner-vs-nix.md) — 同様に「移行コストが ROI に見合わず見送り」となった検討
+- [raycast-dotfiles.md](raycast-dotfiles.md) — 同上。「友人/世間が使っている ≠ 自分の要件に合う」の先例
+
+## 出典
+
+- [cmux 公式サイト](https://cmux.com/)
+- [GitHub - manaflow-ai/cmux](https://github.com/manaflow-ai/cmux)
+- [cmux vs tmux — Agent Terminal vs Terminal Multiplexer (soloterm.com)](https://soloterm.com/cmux-vs-tmux)
+- [tmux vs cmux — Battle-Tested Multiplexer vs the AI Agent Terminal (ice-ice-bear)](https://ice-ice-bear.github.io/posts/2026-03-23-tmux-cmux/)

--- a/docs/terminal-workflow.md
+++ b/docs/terminal-workflow.md
@@ -2,6 +2,8 @@
 
 現在導入済みのツールとショートカットで実現できるユースケース一覧。
 
+> キーボード操作（HRM・Ctrl ナビ・tmux prefix）の一次情報源は [`.config/karabiner/HRM.md`](../.config/karabiner/HRM.md)。tmux 内なら `Prefix` → `m` でいつでも表示できる。本ファイルはツール横断の早見表。
+
 ## Directory Navigation / ディレクトリ移動
 
 | ユースケース | コマンド | ツール |
@@ -12,6 +14,7 @@
 | 親ディレクトリに移動 | `z..` | zoxide (alias) |
 | hagaspa workspace に移動 | `haga` | alias → `z ~/workspaces/hagaspa` |
 | OLTA workspace に移動 | `olta` | alias → `z ~/workspaces/OLTAInc` |
+| ghq 管理リポジトリを fzf で選んで移動 | `repo` | ghq + fzf (command.sh) |
 | fzf でディレクトリ選んで cd | `Alt+C` | fzf |
 
 ## File Search / ファイル検索
@@ -30,7 +33,7 @@
 
 ## Git Operations / Git 操作
 
-| ユースケース | コマンド | alias |
+| ユースケース | コマンド | 定義 |
 |---|---|---|
 | ステータス確認 | `gs` | `git status --short --branch` |
 | 差分確認 (未追跡含む) | `gd` | `git add -N . && git diff` |
@@ -40,17 +43,19 @@
 | コミット (エディタ) | `gcm` | `git commit` |
 | 直前のコミットに追加 | `gca` | `git commit --amend --no-edit` |
 | プッシュ | `gp` | `git push` |
+| upstream を設定してプッシュ | `gpu` | `git push -u origin $(現在ブランチ)` |
 | プル | `gpl` | `git pull` |
-| main に切替 + pull | `gbm` | `git switch main && git pull` |
-| 直前のブランチに切替 | `gb` | `git switch -` |
+| ブランチ切替 | `gb ブランチ名` | `git switch` |
+| 直前のブランチに戻る | `gb-` | `git switch -` |
 | 新ブランチ作成 | `gbc ブランチ名` | `git switch -c` |
+| ブランチを fzf で選んで切替 | `gco` | fzf + `git switch` (command.sh) |
 | soft reset | `grs コミット` | `git reset --soft` |
-| 変更を全取消 | `gnah` | `git nah` |
+| 変更を全取消 | `gnah` | `git reset --hard && git clean -df` (command.sh) |
 | PR をブラウザで開く | `vg` | `gh pr view --web` |
 
 ## Tmux / ターミナル多重化
 
-**Prefix: `Ctrl+B`**
+**Prefix: `Ctrl+Space`**（D=Ctrl ホールド + 右親指 Space の bilateral chord。`Ctrl+B` は左手同手チョードで打ちにくいため変更。詳細は [HRM.md](../.config/karabiner/HRM.md)）
 
 | ユースケース | キー | 備考 |
 |---|---|---|
@@ -59,6 +64,7 @@
 | ウィンドウ番号で切替 | `Prefix` → `0-9` | |
 | ペイン移動 (左/下/上/右) | `Prefix` → `h/j/k/l` | vim 風 |
 | yazi をポップアップで開く | `Prefix` → `y` | Helix 連携あり |
+| HRM チートシート表示 | `Prefix` → `m` | HRM.md を bat でポップアップ |
 | セッション一覧 | `Prefix` → `s` | |
 | ウィンドウ一覧 | `Prefix` → `w` | |
 | ペインを水平分割 | `Prefix` → `"` | |
@@ -67,7 +73,7 @@
 | デタッチ | `Prefix` → `d` | |
 
 **tmux-resurrect / continuum:**
-- セッションは自動保存・自動復元される
+- セッションは自動保存・自動復元される（`@continuum-restore 'on'`）
 - 手動保存: `Prefix` → `Ctrl+S`
 - 手動復元: `Prefix` → `Ctrl+R`
 
@@ -97,21 +103,40 @@ tmux 内から `Prefix` → `y` でポップアップ起動。Helix で開いて
 |---|---|---|
 | ファイル内容を表示 (シンタックスハイライト付き) | `bat ファイル` | bat |
 | ファイル一覧 (カラー + アイコン) | `ls` / `l` | lsd (alias) |
-| 現在のコマンドラインをコピー | `Ctrl+P` → `Ctrl+O` | pbcopy (custom) |
-| 画面クリア | `Ctrl+G` | clear-screen |
+| 現在のコマンドラインをコピー | `Ctrl+P` → `Ctrl+O` | pbcopy (command.sh) |
+| 画面クリア | `Ctrl+G` | clrscr (command.sh) |
 
-## Keyboard Shortcuts (Karabiner) / ターミナル内キーボード
+## Keyboard Shortcuts (Karabiner / HRM)
 
-ターミナルアプリ内でのみ有効な Karabiner リマップ:
+ホームロウmod (HRM) とターミナル向けリマップを Karabiner で定義。**詳細・最新は [HRM.md](../.config/karabiner/HRM.md)（tmux 内なら `Prefix` → `m`）が一次情報源**。設定は `.config/karabiner/karabiner.ts` から `karabiner.json` を生成。以下は要約。
+
+### Home Row Mods（キーをホールドして修飾キーにする）
+
+| キー | ホールド → 修飾 | スコープ |
+|---|---|---|
+| F (左人差し) | Shift | 全アプリ |
+| S (左薬指) | Option | 全アプリ |
+| D (左中指) | Control | 全アプリ |
+| J (右人差し) | Shift | Helix / ターミナル / Chrome を除く |
+| ; (右小指) | Opt + Shift | 全アプリ |
+| Cmd (tap) | 英数 (左) / かな (右) | tap で IME 切替、hold で Cmd |
+
+- A (左小指) には HRM を載せない（左手首腱鞘炎対策）／Cmd は物理キーのまま
+
+### Ctrl navigation（D ホールドで Ctrl を作って発火・全アプリ）
+
+| キー | 動作 |
+|---|---|
+| `Ctrl+H/J/K/L` | 矢印キー (左/下/上/右) |
+| `Ctrl+,` / `Ctrl+.` | 単語単位で左/右移動 (Option+←/→) |
+| `Ctrl+W` / `Ctrl+V` | Page Up / Page Down |
+
+### ターミナル限定
 
 | キー | 動作 | 備考 |
 |---|---|---|
-| `Ctrl+H/J/K/L` | 矢印キー (左/下/上/右) | vim 風カーソル移動 |
-| `Ctrl+,` | 単語単位で左移動 | Alt+Left |
-| `Ctrl+.` | 単語単位で右移動 | Alt+Right |
-| `Ctrl+W` | Page Up | |
-| `Ctrl+V` | Page Down | |
-| `Ctrl+B` | IME off → Ctrl+B | tmux prefix の IME 誤入力防止 |
+| `Ctrl+B` | 英数 → `Ctrl+B` | tmux prefix 送出前に IME を抜く（prefix 自体は `Ctrl+Space`） |
+| `Ctrl` 単押し | 短時間ホールド | 端末向け tap-hold 判定 |
 
 ## Helix Editor / エディタ
 
@@ -138,15 +163,16 @@ gbc feat/my-feature   # ブランチ作成
 gd                     # 差分確認
 ga.                    # 全ファイルステージ
 gc "feat: add feature" # コミット
-gp                     # プッシュ
+gpu                    # 初回プッシュ (upstream 設定)。2 回目以降は gp
 # gh pr create ...
 vg                     # PR をブラウザで開く
 ```
 
 ### 作業中にmainの変更を取り込む
 ```
-gbm        # main に切替 + pull
-gb         # 元のブランチに戻る
+gb main    # main に切替
+gpl        # pull
+gb-        # 元のブランチに戻る
 # git rebase main or git merge main
 ```
 


### PR DESCRIPTION
## Background / 背景

友人が iterm + tmux から cmux へ移行したのをきっかけに、現状の **ghostty + tmux** 環境を cmux に乗り換える価値があるかを検討した。その結論を記録として残す。あわせて、HRM 導入などで実態と乖離していた `terminal-workflow.md` の早見表を最新化する。

## Changes / 変更内容

- **`docs/cmux-vs-tmux.md`（新規）**: cmux（manaflow-ai/cmux）への移行を見送り、ghostty + tmux を継続する結論と根拠を記録。要件（軽い・キーボードのみ）との突き合わせ、移行で失う資産（HRM prefix 設計・resurrect/continuum・detach/reattach 等）、再検討トリガー、出典をまとめた。
- **`docs/terminal-workflow.md`（更新）**:
  - キーボード操作の一次情報源が `.config/karabiner/HRM.md` であることを冒頭に明記
  - tmux prefix を `Ctrl+B` → `Ctrl+Space` に修正
  - git エイリアスの追記・修正（`gpu` / `gb <branch>` / `gb-` / `gco` / `gnah` の実体など）と `repo`・HRM チートシート表示（`Prefix` → `m`）を追加
  - 「Keyboard Shortcuts (Karabiner / HRM)」セクションを新設（Home Row Mods / Ctrl navigation / ターミナル限定）

## Impact scope / 影響範囲

- `docs/` 配下のドキュメントのみ。スクリプト・設定ファイルの挙動には影響なし。

## Testing / 動作確認

- [x] ドキュメント内の相対リンク先がすべて実在することを確認（`.config/karabiner/HRM.md` / `terminal-workflow.md` / `karabiner-vs-nix.md` / `raycast-dotfiles.md`）
- [x] Markdown のテーブル構文・記法を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)