### PR TITLE
chore(claude): set default model to opus 1m

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -58,11 +58,12 @@
       "Bash(kubectl scale:*)",
       "Bash(kubectl rollout:*)"
     ],
+    "defaultMode": "auto",
     "additionalDirectories": [
       "~/Desktop"
-    ],
-    "defaultMode": "auto"
+    ]
   },
+  "model": "opus[1m]",
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "atlassian",
@@ -109,6 +110,6 @@
   },
   "language": "Japanese",
   "effortLevel": "xhigh",
-  "showThinkingSummary": true,
-  "skipAutoPermissionPrompt": true
+  "skipAutoPermissionPrompt": true,
+  "showThinkingSummary": true
 }


### PR DESCRIPTION
## Background / 背景

`/model` で既定モデルを Opus 4.8（1M context）に変更したため、その選択を dotfiles 管理の `settings.json` に永続化する。

## Changes / 変更内容

- `.config/claude/settings.json` に `"model": "opus[1m]"` を追加
- 設定保存に伴うキーの並び替え（`defaultMode` / `showThinkingSummary` / `skipAutoPermissionPrompt`）が差分に含まれるが、いずれも意味的な変更はない

## Impact scope / 影響範囲

- `~/.claude/settings.json`（dotfiles 管理）の既定モデル設定のみ。新規セッションのデフォルトモデルが Opus 4.8 1M になる
- `effortLevel: xhigh` 等の既存設定は変更なし

## Testing / 動作確認

- [x] `jq empty` で JSON として妥当であることを確認
- [x] terminal-workflow doc PR (#123) と変更が混在していないことを確認（main から切った別ブランチ）