### PR TITLE
chore(settings): disable kotoeri predictive candidates

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -24,6 +24,13 @@ defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 defaults write com.apple.symbolichotkeys.plist AppleSymbolicHotKeys -dict-add 60 \
   '{enabled = 0; value = { parameters = (32, 49, 262144); type = "standard"; }; }'
 
+# Japanese IME (Kotoeri): disable predictive candidates and live conversion.
+# Predictive candidates cause heavily-learned words to be mis-committed during
+# fast typing (random kanji/English appearing mid-sentence); live conversion is
+# kept off per preference. Requires logout/login to take effect (esp. macOS Tahoe 26+).
+defaults write com.apple.inputmethod.Kotoeri JIMPrefPredictiveCandidateKey -bool false
+defaults write com.apple.inputmethod.Kotoeri JIMPrefLiveConversionKey -bool false
+
 echo "macOS settings applied. Please restart your system for all changes to take effect."
 echo ""
 echo -e "\033[1;33m⚠️  RESTART REQUIRED\033[0m"


### PR DESCRIPTION
## Background / 背景

macOS 標準の日本語入力（ことえり）の**推測変換**が、強く学習した語（業務でよく打つ語や K8s 学習ノートの "main"/"ca" 等）を高速入力中に確定操作で巻き込み、文中にランダムな漢字・英単語が混入する問題が発生していた。原因は IME の推測変換で、Karabiner や azooKey は無関係（Karabiner OFF でも再現・純正 IME のみ使用、で切り分け済み）。

## Changes / 変更内容

`settings.sh` に macOS 純正 IME（Kotoeri）の `defaults` 設定を2行追加:

- `JIMPrefPredictiveCandidateKey` → `false`（推測候補を表示 OFF）… 今回の混入対処
- `JIMPrefLiveConversionKey` → `false`（ライブ変換 OFF）… 既存の運用設定を移植

これにより、新しい Mac でも `./settings.sh` 実行でこの設定が自動適用される（PC 移行時の手動設定が不要に）。

## Impact scope / 影響範囲

- `settings.sh` のみ（末尾 echo の直前に追記、既存設定への影響なし）
- 反映には再ログインが必要（特に macOS Tahoe 26+ で plist が即時反映されないため）
- 設定済みマシンで再実行しても変化なし（冪等）

## Testing / 動作確認

- [x] `bash -n settings.sh` で構文チェック通過
- [x] 対象キーの型が boolean であることを `defaults read-type` で確認
- [x] 推測候補 OFF 後、Obsidian で誤入力（「投資効率」等の混入）が再現しないことを手動確認