### PR TITLE
chore(k8s): add yq/stern and color-code kube contexts

### DIFF
--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -7,5 +7,22 @@ format = """$directory$git_branch$git_status$kubernetes$gcloud$all"""
 format = '[$symbol$active]($style) '
 
 [kubernetes]
-format = '[$context](bright-yellow) '
+format = '[$context]($style) '
+style = "bright-yellow"
 disabled = false
+
+[[kubernetes.contexts]]
+context_pattern = "prd-.*"
+style = "bold red"
+
+[[kubernetes.contexts]]
+context_pattern = "stg-.*"
+style = "yellow"
+
+[[kubernetes.contexts]]
+context_pattern = "dev.*"
+style = "green"
+
+[[kubernetes.contexts]]
+context_pattern = "kind-.*"
+style = "dimmed green"

--- a/Brewfile
+++ b/Brewfile
@@ -20,6 +20,10 @@ brew "git-delta"
 brew "tmux"
 brew "typescript-language-server"
 
+# Kubernetes / YAML
+brew "yq"
+brew "stern"
+
 # Runtime management
 brew "mise"
 


### PR DESCRIPTION
## Background / 背景

K8s 学習を進める中で、YAML 操作とログ閲覧の頻度が増えてきた。また業務 GKE と自宅 kind を行き来する際に、現在の context を取り違える事故を防ぎたい。

## Changes / 変更内容

- Brewfile に `yq`（YAML 操作）と `stern`（複数 Pod ログ tail）を追加
- starship の kubernetes module に context 別の色分けを追加
  - `prd-*` → bold red（本番、最高警戒）
  - `stg-*` → yellow（ステージング）
  - `dev*` → green（開発）
  - `kind-*` → dimmed green（自宅 kind）
  - その他 → bright-yellow（フォールバック、未知 context 用に残す）

`k9s` も検討したが、書き込みは kubectl 一本に絞る方針で見送り。観察は `stern` + `kubectl get/describe/logs` でまかなう。

## Impact scope / 影響範囲

- **Brewfile**: 新規 CLI 追加のみ。既存ツールへの影響なし
- **starship**: format string 内の hardcode color (`(bright-yellow)`) を `$style` 変数参照に変更。default style は維持しているため、未知 context でも従来通りの色で表示される

## Testing / 動作確認

- [x] `brew install yq stern` 実行、コマンドが PATH に通ることを確認
- [x] `starship module kubernetes` で各 context (kind/dev/stg/prd) の色が ANSI で意図通り出ることを確認
- [x] `KUBECONFIG=/dev/null` で module が空になること、未知の context で default style (bright-yellow) にフォールバックすることを確認