### PR TITLE
fix(ci): pin claude action model to sonnet-4-6

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,10 +36,8 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: "claude-sonnet-4-6"
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide feedback on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,14 +35,12 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          model: "claude-sonnet-4-6"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
+
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
           


### PR DESCRIPTION
## Background / 背景

2026-06-16 から claude-code-review の GitHub Actions が落ちるようになった。原因は `anthropics/claude-code-action@beta` がデフォルトで使うモデル ID `claude-sonnet-4-20250514` が Anthropic API 側で廃止され、404 が返るようになったため。

該当ジョブログ抜粋:

```
API Error: 404 {"type":"error","error":{"type":"not_found_error","message":"model: claude-sonnet-4-20250514"}}
```

## Changes / 変更内容

- `.github/workflows/claude-code-review.yml` と `.github/workflows/claude.yml` の双方で `model: "claude-sonnet-4-6"` を明示指定
- 古いモデル ID を含むコメント行を削除（action 側のデフォルト変更を待たず利用側で明示する方針）

## Impact scope / 影響範囲

- PR 作成時の自動レビュー（claude-code-review）
- Issue/PR コメントでの `@claude` メンション応答（claude.yml）
- 設定はすべて利用側のリポジトリで完結。Secrets や Action のバージョンは変更していない

## Testing / 動作確認

- [x] YAML として valid であること（既存の test-scripts.yml の対象外なので目視確認）
- [ ] この PR の起動で claude-code-review が success になることを確認