### PR TITLE
feat(zed): add zed editor with karabiner hrm exclusion

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -9,7 +9,7 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 | F (left index)  | Shift           | All apps                              |
 | S (left ring)   | Option          | All apps                              |
 | D (left middle) | Control         | All apps                              |
-| J (right index) | Shift           | All except Helix / Terminal / Chrome  |
+| J (right index) | Shift           | All except Terminal / Chrome / Zed / Cursor |
 | ; (right pinky) | Opt + Shift     | All apps                              |
 
 - A pinky には HRM を載せない (左手首腱鞘炎対策)

--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -5102,7 +5102,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5143,7 +5145,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5184,7 +5188,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5225,7 +5231,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5266,7 +5274,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5307,7 +5317,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5348,7 +5360,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5389,7 +5403,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5430,7 +5446,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5471,7 +5489,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5512,7 +5532,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5553,7 +5575,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5594,7 +5618,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5635,7 +5661,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5676,7 +5704,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5717,7 +5747,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5758,7 +5790,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5799,7 +5833,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5840,7 +5876,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5881,7 +5919,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5922,7 +5962,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -5963,7 +6005,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6004,7 +6048,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6045,7 +6091,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6086,7 +6134,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6127,7 +6177,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6168,7 +6220,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6209,7 +6263,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6250,7 +6306,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6291,7 +6349,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6332,7 +6392,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6373,7 +6435,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6414,7 +6478,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6455,7 +6521,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6496,7 +6564,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6537,7 +6607,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6578,7 +6650,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6619,7 +6693,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6660,7 +6736,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6701,7 +6779,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6742,7 +6822,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6783,7 +6865,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6824,7 +6908,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6865,7 +6951,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6906,7 +6994,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6947,7 +7037,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -6988,7 +7080,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7029,7 +7123,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7070,7 +7166,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7111,7 +7209,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7152,7 +7252,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7193,7 +7295,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7234,7 +7338,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7275,7 +7381,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7316,7 +7424,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7357,7 +7467,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7398,7 +7510,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7439,7 +7553,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]
@@ -7479,7 +7595,9 @@
                       "^com\\.github\\.wez\\.wezterm$",
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$"
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
                     ]
                   }
                 ]

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -18,6 +18,8 @@ const ifTerminal = ifApp({ bundle_identifiers: [...TERMINAL_BUNDLE_IDS] });
 const VIM_APP_IDS = [
   ...TERMINAL_BUNDLE_IDS,
   '^com\\.google\\.Chrome$',
+  '^dev\\.zed\\.Zed$',
+  '^com\\.todesktop\\.230313mzl4w4u92$',
 ] as const;
 const unlessVimApp = ifApp({
   bundle_identifiers: [...VIM_APP_IDS],

--- a/.config/karabiner/package.json
+++ b/.config/karabiner/package.json
@@ -3,8 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun run karabiner.ts",
-    "watch": "bun run --watch karabiner.ts"
+    "build": "bun run karabiner.ts && bun run reload",
+    "watch": "bun run --watch karabiner.ts",
+    "reload": "if [ -x \"/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli\" ]; then \"/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli\" --select-profile 'Default profile'; fi"
   },
   "dependencies": {
     "karabiner.ts": "^1.36.0"

--- a/.config/zed/settings.json
+++ b/.config/zed/settings.json
@@ -1,0 +1,28 @@
+// Zed settings
+//
+// For information on how to configure Zed, see the Zed
+// documentation: https://zed.dev/docs/configuring-zed
+//
+// To see all of Zed's default settings without changing your
+// custom settings, run `zed: open default settings` from the
+// command palette (cmd-shift-p / ctrl-shift-p)
+{
+  "cli_default_open_behavior": "new_window",
+  "use_system_window_tabs": true,
+  "session": {
+    "trust_all_worktrees": true
+  },
+  "vim_mode": true,
+  "icon_theme": {
+    "mode": "dark",
+    "light": "Zed (Default)",
+    "dark": "Zed (Default)"
+  },
+  "ui_font_size": 16,
+  "buffer_font_size": 15,
+  "theme": {
+    "mode": "dark",
+    "light": "Gruvbox Light",
+    "dark": "Ayu Mirage"
+  }
+}

--- a/Brewfile
+++ b/Brewfile
@@ -30,4 +30,5 @@ brew "mise"
 # GUI Apps
 cask "ghostty"
 cask "cursor"
+cask "zed"
 cask "font-hack-nerd-font"

--- a/link.sh
+++ b/link.sh
@@ -20,6 +20,7 @@ entries=(
   .config/yazi/keymap.toml
   .config/yazi/package.toml
   .config/yazi/yazi.toml
+  .config/zed/settings.json
   .config/zsh/alias.sh
   .config/zsh/command.sh
   .config/zsh/hosts/work.sh


### PR DESCRIPTION
## Background / 背景

Cursor の代替候補として Zed を試したい。インストール後、vim モードで `j` を押しっぱなしにしても連続入力されないことが判明（Cursor でも同じ症状）。原因は Karabiner の Home Row Mods で J→Shift が両アプリで有効になっていたため。さらに `bun run build` で `karabiner.json` を更新しても Karabiner v16 が symlink 経由の変更を fsevents で拾わず、自動 reload されない問題も合わせて対処。加えて、今後の使用を見据えて Zed の `settings.json` も dotfiles で管理する。

## Changes / 変更内容

- `Brewfile`: `cask "zed"` を追加
- `.config/karabiner/karabiner.ts`: `VIM_APP_IDS` に Zed (`^dev\.zed\.Zed$`) と Cursor (`^com\.todesktop\.230313mzl4w4u92$`) を追加し、両アプリで J→Shift HRM を無効化（j のキーリピートを確保）
- `.config/karabiner/karabiner.json`: 再ビルド結果
- `.config/karabiner/HRM.md`: 対象除外アプリの表記を更新
- `.config/karabiner/package.json`: `build` スクリプトに `karabiner_cli --select-profile 'Default profile'` を連鎖する `reload` を追加。`karabiner_cli` が存在しない CI runner では `if [ -x ... ]` で no-op になり `test-karabiner-build.sh` を壊さない
- `.config/zed/settings.json`: Zed のユーザー設定を新規追加（`cli_default_open_behavior: new_window`、`vim_mode`、テーマ等）
- `link.sh`: `entries` に `.config/zed/settings.json` を追加し、`~/.config/zed/settings.json` への symlink を作成

## Impact scope / 影響範囲

- ローカル macOS の Brew 環境（Zed 追加）
- Karabiner-Elements の HRM 動作（Zed / Cursor で j がリピートするようになる、他アプリは無影響）
- `bun run build` の挙動（macOS では reload まで自動化、CI では従来通り）
- `~/.config/zed/settings.json` が dotfiles 配下の symlink になる（元ファイルは `.bak` でバックアップ済み）

## Testing / 動作確認

- [x] `brew bundle --file=Brewfile` 完走、`/Applications/Zed.app` 起動確認
- [x] Zed の vim モードで `j` 長押し → 連続移動を確認
- [x] Cursor でも同様に `j` 連続入力を確認
- [x] `cd .config/karabiner && bun run build` で karabiner.json 再生成 → `/var/log/karabiner/core_service.log` に `Load .../karabiner.json` → `core_configuration is updated.` が出ることを確認
- [x] `./link.sh` で `~/.config/zed/settings.json` → repo 内ファイルへの symlink が貼られ、`.bak` バックアップが作成されることを確認
- [ ] CI (`test-karabiner-build.sh`) が Linux runner で壊れないこと（PR push 後の GH Actions で確認）