### PR TITLE
feat(nvim): add neovim with minimal init.lua

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,0 +1,91 @@
+-- Minimal neovim config. No plugin manager, built-ins only.
+
+vim.g.mapleader = ' '
+vim.g.maplocalleader = ' '
+
+-- ===== Options =====
+local opt = vim.opt
+
+opt.number = true
+opt.relativenumber = true
+opt.cursorline = true
+opt.signcolumn = 'yes'
+opt.scrolloff = 8
+opt.wrap = false
+
+opt.expandtab = true
+opt.shiftwidth = 2
+opt.tabstop = 2
+opt.smartindent = true
+
+opt.ignorecase = true
+opt.smartcase = true
+opt.incsearch = true
+opt.hlsearch = true
+
+opt.splitright = true
+opt.splitbelow = true
+
+opt.swapfile = false
+opt.backup = false
+opt.undofile = true
+
+opt.termguicolors = true
+opt.showmode = false
+opt.updatetime = 250
+opt.timeoutlen = 400
+
+opt.clipboard = 'unnamedplus'
+opt.completeopt = { 'menuone', 'noselect', 'noinsert' }
+
+-- Built-in fuzzy file find via :find
+opt.path:append('**')
+opt.wildmode = 'longest:full,full'
+opt.wildignore:append({ '*/node_modules/*', '*/.git/*', '*/dist/*', '*/build/*' })
+
+-- ===== Keymaps =====
+local map = vim.keymap.set
+
+map('n', '<Esc>', '<cmd>nohlsearch<CR>')
+
+-- Window navigation
+map('n', '<C-h>', '<C-w>h')
+map('n', '<C-j>', '<C-w>j')
+map('n', '<C-k>', '<C-w>k')
+map('n', '<C-l>', '<C-w>l')
+
+-- Center cursor on big jumps / search
+map('n', '<C-d>', '<C-d>zz')
+map('n', '<C-u>', '<C-u>zz')
+map('n', 'n', 'nzzzv')
+map('n', 'N', 'Nzzzv')
+
+-- Paste without yanking replaced text
+map('x', '<leader>p', '"_dP')
+
+-- File / buffer navigation (built-in)
+map('n', '<leader>e', '<cmd>Explore<CR>')
+map('n', '<leader>f', ':find ')
+map('n', '<leader>b', ':buffer ')
+map('n', '[b', '<cmd>bprevious<CR>')
+map('n', ']b', '<cmd>bnext<CR>')
+
+map('n', '<leader>w', '<cmd>write<CR>')
+map('n', '<leader>q', '<cmd>quit<CR>')
+
+-- ===== Autocommands =====
+local augroup = vim.api.nvim_create_augroup('user', { clear = true })
+
+vim.api.nvim_create_autocmd('TextYankPost', {
+  group = augroup,
+  callback = function() vim.highlight.on_yank({ timeout = 150 }) end,
+})
+
+vim.api.nvim_create_autocmd('BufWritePre', {
+  group = augroup,
+  callback = function()
+    local save = vim.fn.winsaveview()
+    vim.cmd([[keeppatterns %s/\s\+$//e]])
+    vim.fn.winrestview(save)
+  end,
+})

--- a/Brewfile
+++ b/Brewfile
@@ -13,6 +13,7 @@ brew "atuin"
 
 # Editor
 brew "helix"
+brew "neovim"
 
 # Development
 brew "gh"

--- a/link.sh
+++ b/link.sh
@@ -15,6 +15,7 @@ entries=(
   .config/helix/yazi-picker.sh
   .config/karabiner/HRM.md
   .config/karabiner/karabiner.json
+  .config/nvim/init.lua
   .config/sheldon/plugins.toml
   .config/yazi/init.lua
   .config/yazi/keymap.toml


### PR DESCRIPTION
## Background / 背景

Claude Code 中心のワークフローへ移行するにあたり、エディタの主用途が「タイピング」から「diff の読み解き / review」に変化している。Zed をプライマリにする方針を試すあたり、`$EDITOR` フォールバック（git commit、SSH 先、sudoedit）として動く軽量 TUI エディタが必要。

helix は LSP UX とエラー視認性に課題があり、また編集モデルが Zed (vim mode) と乖離している。vim 流派に統一する目的で neovim を導入。プラグインなし・最小 init.lua で起動 ~43ms（cold start, fully loaded）を実測済み。

This change adds neovim as a minimal `$EDITOR` fallback, complementing Zed as the primary GUI editor. No plugins, built-ins only, ~75 lines of `init.lua`.

## Changes / 変更内容

- `Brewfile`: add `brew "neovim"` to the Editor section
- `link.sh`: add `.config/nvim/init.lua` entry (alphabetical position between karabiner and sheldon)
- `.config/nvim/init.lua` を新規作成
  - プラグインマネージャなし、ビルトインのみ
  - Leader = Space、netrw / `:find` ベースのファイル操作
  - LSP 設定は未投入（`$EDITOR` 用途では不要、必要になったら言語ごとに追加）

## Impact scope / 影響範囲

- 新規ファイル追加と Brewfile / link.sh への追記のみ
- 既存の helix / Zed 設定には変更なし
- 既存ユーザー（自分）への影響: `brew bundle` と `./link.sh` 実行で neovim と symlink が入る

## Testing / 動作確認

- [x] `brew install neovim` 成功（v0.12.3）
- [x] `./link.sh` で symlink 作成（`~/.config/nvim/init.lua` → dotfiles）
- [x] `nvim --headless -c 'qa'` でエラーなく起動
- [x] `nvim --startuptime` で 43ms 計測（cold start, init.lua フルロード後）
- [x] `:e` / `:find` / `:Explore` / `<Space>e` / `<Space>f` の主要キーマップ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)