### PR TITLE
chore(claude): pin model to opus 4.7 and enable fullscreen tui

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -63,7 +63,7 @@
       "~/Desktop"
     ]
   },
-  "model": "opus[1m]",
+  "model": "claude-opus-4-7",
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "atlassian",
@@ -111,5 +111,6 @@
   "language": "Japanese",
   "effortLevel": "xhigh",
   "skipAutoPermissionPrompt": true,
-  "showThinkingSummary": true
+  "showThinkingSummary": true,
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
## Background / 背景

- デフォルトモデル指定 `opus[1m]` は 1M context のエイリアスだが、Opus 4.8 は性能が悪いため明示的に 4.7 にピン留めしておきたい
- TUI を fullscreen で固定したい

## Changes / 変更内容

- `.config/claude/settings.json` の `model` を `opus[1m]` → `claude-opus-4-7` に変更
- `tui: "fullscreen"` を追加

## Impact scope / 影響範囲

- ローカルの Claude Code 起動時のデフォルトモデルと TUI レンダリングモードのみ
- 他の dotfiles 設定・スクリプトには影響なし

## Testing / 動作確認

- [x] `.config/claude/settings.json` の JSON 構文確認
- [x] Claude Code 起動時にモデルが `claude-opus-4-7` で動作することを確認
- [x] TUI が fullscreen モードで起動することを確認