### PR TITLE
feat(yaml): add yaml-language-server with kubernetes schema

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -89,3 +89,42 @@ vim.api.nvim_create_autocmd('BufWritePre', {
     vim.fn.winrestview(save)
   end,
 })
+
+-- ===== LSP =====
+-- yaml-language-server (Kubernetes schema scoped to bons8i-style kustomize layout)
+vim.lsp.config('yamlls', {
+  cmd = { 'yaml-language-server', '--stdio' },
+  filetypes = { 'yaml' },
+  root_markers = { '.git' },
+  settings = {
+    yaml = {
+      schemas = {
+        kubernetes = {
+          'base/**/*.yaml',
+          'overlays/**/*.yaml',
+          'clusters/**/*.yaml',
+        },
+      },
+      validate = true,
+      completion = true,
+      hover = true,
+    },
+  },
+})
+vim.lsp.enable('yamlls')
+
+vim.api.nvim_create_autocmd('LspAttach', {
+  group = augroup,
+  callback = function(args)
+    local buf = args.buf
+    local opts = { buffer = buf }
+    map('n', 'K', vim.lsp.buf.hover, opts)
+    map('n', 'gd', vim.lsp.buf.definition, opts)
+    map('n', '<leader>rn', vim.lsp.buf.rename, opts)
+    map('n', '<leader>ca', vim.lsp.buf.code_action, opts)
+    map('n', '[d', function() vim.diagnostic.jump({ count = -1, float = true }) end, opts)
+    map('n', ']d', function() vim.diagnostic.jump({ count = 1, float = true }) end, opts)
+    map('n', '<leader>d', vim.diagnostic.open_float, opts)
+    vim.lsp.completion.enable(true, args.data.client_id, buf, { autotrigger = true })
+  end,
+})

--- a/.config/zed/settings.json
+++ b/.config/zed/settings.json
@@ -24,5 +24,20 @@
     "mode": "dark",
     "light": "Gruvbox Light",
     "dark": "Ayu Mirage"
+  },
+  "lsp": {
+    "yaml-language-server": {
+      "settings": {
+        "yaml": {
+          "schemas": {
+            "kubernetes": [
+              "base/**/*.yaml",
+              "overlays/**/*.yaml",
+              "clusters/**/*.yaml"
+            ]
+          }
+        }
+      }
+    }
   }
 }

--- a/Brewfile
+++ b/Brewfile
@@ -24,6 +24,7 @@ brew "typescript-language-server"
 # Kubernetes / YAML
 brew "yq"
 brew "stern"
+brew "yaml-language-server"
 
 # Runtime management
 brew "mise"


### PR DESCRIPTION
## Background / 背景

K8s 自宅クラスタ PJ で kustomize 配下の YAML マニフェストを扱うため、Neovim と Zed の両方で YAML LSP による補完・バリデーション・ホバーを効かせたい。

## Changes / 変更内容

- `Brewfile`: `yaml-language-server` を追加
- `.config/nvim/init.lua`: `vim.lsp.config` / `vim.lsp.enable` で yamlls を有効化し、`base/`・`overlays/`・`clusters/` 配下の YAML に Kubernetes schema を割り当て。`LspAttach` autocmd で `K` / `gd` / `<leader>rn` / `<leader>ca` / `[d` / `]d` / `<leader>d` を bind し、`vim.lsp.completion.enable` で autotrigger 補完を ON
- `.config/zed/settings.json`: Zed 側にも同じ Kubernetes schema パターン（`base/**` / `overlays/**` / `clusters/**`）を LSP settings として設定

## Impact scope / 影響範囲

- 新規に導入する LSP のみで、既存の LSP 設定・キーマップには影響しない
- Kubernetes schema のマッチパスは kustomize レイアウト前提。プレーンな `*.yaml` は Kubernetes として扱われないので誤検知は起きない想定

## Testing / 動作確認

- [x] `brew bundle` で `yaml-language-server` がインストールできる / brew install で確認
- [x] `nvim base/foo.yaml` で LSP が attach し、`apiVersion` などに補完が効くこと
- [x] Zed で `overlays/*.yaml` を開いて YAML LSP の補完・診断が効くこと