### PR TITLE
feat(tmux): open terminal-workflow cheatsheet via Prefix+M popup

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -67,6 +67,11 @@ bind y run-shell -b 'tmux display-popup -d "#{pane_current_path}" -w 80% -h 80% 
 unbind m
 bind m display-popup -w 80% -h 80% -E "bat --style=plain --color=always --paging=always ~/.config/karabiner/HRM.md"
 
+# ツール横断のワークフロー早見表を popup で開く (docs/terminal-workflow.md の symlink)
+# 既定の `M` (select-pane -M / マーク解除) は使わないので上書き
+unbind M
+bind M display-popup -w 80% -h 80% -E "bat --style=plain --color=always --paging=always ~/.config/tmux/terminal-workflow.md"
+
 # エスケープシーケンスの待機時間を0にする（キー入力の応答性向上）
 set -sg escape-time 0
 

--- a/link.sh
+++ b/link.sh
@@ -36,6 +36,7 @@ entries=(
   ".config/cursor/keybindings.json:~/Library/Application Support/Cursor/User/keybindings.json"
   ".config/starship/starship.toml:~/.config/starship.toml"
   ".config/tmux/tmux.conf:~/.tmux.conf"
+  "docs/terminal-workflow.md:~/.config/tmux/terminal-workflow.md"
   ".config/claude/settings.json:~/.claude/settings.json"
   ".config/claude/commands:~/.claude/commands"
 )


### PR DESCRIPTION
## Background / 背景

ツール横断の早見表 `docs/terminal-workflow.md` を、キーボードだけで素早く参照したい。すでに HRM チートシート（`.config/karabiner/HRM.md`）は `Prefix → m` で tmux popup 表示できるが、ワークフロー早見表には同等の導線がなかった。両者は役割が異なる（HRM.md = キーボードレイヤーの一次情報源 / terminal-workflow.md = ツール横断の早見表）ため統合はせず、別キーで popup 表示できるようにする。

## Changes / 変更内容

- `tmux.conf`: `Prefix → M`（大文字）に `display-popup` を追加。HRM.md の `bind m` と同じ `bat` popup 方式で `docs/terminal-workflow.md` を表示。既定の `M`（select-pane -M / マーク解除）は未使用のため上書き
- `link.sh`: `docs/terminal-workflow.md:~/.config/tmux/terminal-workflow.md` の symlink entry を追加。tmux.conf が既存 popup（HRM.md / yazi-picker.sh）と同じく `~/.config/…` の安定パスを参照できるようにする（マシン依存の絶対パス直書きを回避）

## Impact scope / 影響範囲

- tmux のキーバインド `Prefix → M` を新設（既定のマーク解除機能を上書きするが、現状マーク機能は未使用）
- `~/.config/tmux/terminal-workflow.md` に新規 symlink を作成
- 既存の挙動・他ショートカットへの影響なし

## Testing / 動作確認

- [x] 別ソケット（`tmux -L synctest -f …`）で tmux.conf の構文が有効なことを確認
- [x] `bind M` が `display-popup … bat … ~/.config/tmux/terminal-workflow.md` として登録されることを `list-keys` で確認
- [x] symlink 経由で `bat ~/.config/tmux/terminal-workflow.md` が表示できることを確認
- [x] 稼働中の tmux に `source-file` で反映し、`bind M` の登録を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
