### PR TITLE
chore(claude): switch to opus 1m model and consolidate effort level

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -63,7 +63,7 @@
       "~/Desktop"
     ]
   },
-  "model": "claude-opus-4-7",
+  "model": "opus[1m]",
   "enableAllProjectMcpServers": true,
   "enabledMcpjsonServers": [
     "atlassian",
@@ -109,8 +109,8 @@
     "rust-analyzer-lsp@claude-plugins-official": true
   },
   "language": "Japanese",
-  "effortLevel": "xhigh",
+  "effortLevel": "high",
+  "tui": "fullscreen",
   "skipAutoPermissionPrompt": true,
-  "showThinkingSummary": true,
-  "tui": "fullscreen"
+  "showThinkingSummary": true
 }

--- a/.zshenv
+++ b/.zshenv
@@ -6,7 +6,7 @@ export LANG=en_US.UTF-8
 export LESSCHARSET=utf-8
 
 # Claude Code
-export CLAUDE_CODE_EFFORT_LEVEL=max
+# export CLAUDE_CODE_EFFORT_LEVEL=max
 
 # Add user-local binaries to PATH
 export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Background / 背景

Claude Code のモデルを 1M コンテキスト版に切り替え、effort level の管理方針を見直す。これまで env var (`CLAUDE_CODE_EFFORT_LEVEL=max`) を実効値、settings.json (`xhigh`) を fallback として二重管理していたが、settings.json 側に一本化する。

## Changes / 変更内容

- モデルを `claude-opus-4-7` から `opus[1m]`（1M コンテキスト版）に変更
- `effortLevel` を `xhigh` から `high` に変更
- `CLAUDE_CODE_EFFORT_LEVEL=max` 環境変数をコメントアウトし、settings.json の `effortLevel` に管理を一本化

## Impact scope / 影響範囲

- Claude Code の設定のみ（`.config/claude/settings.json`, `.zshenv`）
- 他のツール・スクリプト・シェル動作への影響なし

## Testing / 動作確認

- [x] settings.json の JSON 構文が正しいこと（`jq . < .config/claude/settings.json`）
- [x] .zshenv が正しく読み込めること（`zsh -n .zshenv`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
