### PR TITLE
feat(crit): add crit code review tool and enable plugin

### DIFF
--- a/.config/claude/settings.json
+++ b/.config/claude/settings.json
@@ -106,7 +106,16 @@
     "playwright@claude-plugins-official": true,
     "atlassian@claude-plugins-official": true,
     "claude-md-management@claude-plugins-official": true,
-    "rust-analyzer-lsp@claude-plugins-official": true
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "crit@crit": true
+  },
+  "extraKnownMarketplaces": {
+    "crit": {
+      "source": {
+        "source": "github",
+        "repo": "tomasz-tomczyk/crit"
+      }
+    }
   },
   "language": "Japanese",
   "effortLevel": "high",

--- a/Brewfile
+++ b/Brewfile
@@ -20,6 +20,7 @@ brew "gh"
 brew "git-delta"
 brew "tmux"
 brew "typescript-language-server"
+brew "crit"
 
 # Kubernetes / YAML
 brew "yq"


### PR DESCRIPTION
## Background / 背景

AI エージェントとのコードレビューのフィードバックループを回すため、ローカルファーストなレビューツール [crit](https://crit.md/) を導入する。

## Changes / 変更内容

- `Brewfile`: `crit` を Development セクションに追加（homebrew-core 正式 formula）
- `.config/claude/settings.json`: `crit@crit` プラグインを有効化し、マーケットプレイス `tomasz-tomczyk/crit` を登録（`/crit` コマンドと `crit`/`crit-cli` スキルが全プロジェクトで利用可能に）

## Impact scope / 影響範囲

- Homebrew の管理パッケージに `crit` が1つ追加される
- Claude Code のグローバル設定にプラグインとマーケットプレイスが追加される。既存のプラグイン設定・他の項目には影響なし

## Testing / 動作確認

- [x] `brew bundle` で `crit` インストール成功（`crit 0.17.0` 動作確認）
- [x] `crit@crit` プラグイン enabled を確認（`claude plugin list`）
- [x] dotfiles の変更を `crit` で起動 → コメント追加 → `crit comments` で取得できることを確認