### PR TITLE
feat(karabiner): remap semicolon hold to cmd+opt+ctrl for raycast

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -10,7 +10,7 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 | S (left ring)   | Option          | All apps                              |
 | D (left middle) | Control         | All apps                              |
 | J (right index) | Shift           | All except Terminal / Chrome / Zed / Cursor |
-| ; (right pinky) | Opt + Shift     | All apps                              |
+| ; (right pinky) | ⌘⌥⌃ (Raycast 用) | All apps                              |
 
 - A pinky には HRM を載せない (左手首腱鞘炎対策)
 - Cmd は物理キーのまま (HRM 化しない)

--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -1,4762 +1,7708 @@
 {
-    "profiles": [
-        {
-            "complex_modifications": {
-                "rules": [
-                    {
-                        "description": "Terminal Ctrl tap-hold + tmux IME bypass",
-                        "manipulators": [
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$"
-                                        ],
-                                        "type": "frontmost_application_if"
-                                    }
-                                ],
-                                "from": {
-                                    "key_code": "left_control",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "parameters": { "basic.to_if_alone_timeout_milliseconds": 300 },
-                                "to": [
-                                    {
-                                        "key_code": "left_control",
-                                        "lazy": true
-                                    }
-                                ],
-                                "to_if_alone": [
-                                    {
-                                        "hold_down_milliseconds": 300,
-                                        "key_code": "left_control"
-                                    }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$"
-                                        ],
-                                        "type": "frontmost_application_if"
-                                    }
-                                ],
-                                "from": {
-                                    "key_code": "b",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [
-                                    { "key_code": "japanese_eisuu" },
-                                    {
-                                        "key_code": "b",
-                                        "modifiers": ["left_control"]
-                                    }
-                                ],
-                                "type": "basic"
-                            }
-                        ]
-                    },
-                    {
-                        "description": "Ctrl navigation (hjkl / word / page)",
-                        "manipulators": [
-                            {
-                                "from": {
-                                    "key_code": "comma",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "left_arrow",
-                                        "modifiers": ["left_option"]
-                                    }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "period",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "right_arrow",
-                                        "modifiers": ["left_option"]
-                                    }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "w",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [{ "key_code": "page_up" }],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "v",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [{ "key_code": "page_down" }],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "h",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [{ "key_code": "left_arrow" }],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "j",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [{ "key_code": "down_arrow" }],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "k",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [{ "key_code": "up_arrow" }],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "l",
-                                    "modifiers": {
-                                        "mandatory": ["left_control"],
-                                        "optional": ["any"]
-                                    }
-                                },
-                                "to": [{ "key_code": "right_arrow" }],
-                                "type": "basic"
-                            }
-                        ]
-                    },
-                    {
-                        "description": "Home Row Mods (Cmd+Opt+Ctrl on ;)",
-                        "manipulators": [
-                            {
-                                "from": {
-                                    "key_code": "semicolon",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "parameters": {
-                                    "basic.to_if_alone_timeout_milliseconds": 200,
-                                    "basic.to_if_held_down_threshold_milliseconds": 200
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "right_command",
-                                        "lazy": true,
-                                        "modifiers": ["right_control", "right_option"]
-                                    }
-                                ],
-                                "to_if_alone": [{ "key_code": "semicolon" }],
-                                "type": "basic"
-                            }
-                        ]
-                    },
-                    {
-                        "description": "Home Row Mods (Shift on F, Opt on S, Ctrl on D)",
-                        "manipulators": [
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "q" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "q" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "q" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "q" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "w" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "w" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "w" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "w" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "e" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "e" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "e" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "e" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "r" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "r" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "r" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "r" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "t" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "t" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "t" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "t" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "a" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "a" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "a" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "a" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "g" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "g" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "g" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "g" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "z" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "z" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "z" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "z" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "x" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "x" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "x" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "x" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "c" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "c" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "c" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "c" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "v" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "v" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "v" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "v" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "b" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "b" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "b" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "b" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "y" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "y" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "y" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "y" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "u" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "u" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "u" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "u" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "i" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "i" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "i" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "i" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "o" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "o" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "o" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "o" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "p" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "p" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "p" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "p" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "h" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "h" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "h" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "h" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "k" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "k" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "k" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "k" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "l" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "l" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "l" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "l" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "semicolon" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "semicolon" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "semicolon" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "semicolon" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "n" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "n" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "n" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "n" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "m" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "m" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "m" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "m" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "comma" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "comma" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "comma" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "comma" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "period" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "period" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "period" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "period" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "slash" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "slash" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "slash" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "slash" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "f",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "parameters": {
-                                    "basic.to_if_alone_timeout_milliseconds": 200,
-                                    "basic.to_if_held_down_threshold_milliseconds": 200
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "left_shift",
-                                        "lazy": true
-                                    }
-                                ],
-                                "to_if_alone": [{ "key_code": "f" }],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "q" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "q" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "q" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "q" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "w" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "w" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "w" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "w" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "e" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "e" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "e" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "e" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "r" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "r" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "r" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "r" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "t" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "t" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "t" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "t" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "a" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "a" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "a" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "a" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "g" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "g" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "g" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "g" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "z" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "z" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "z" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "z" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "x" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "x" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "x" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "x" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "c" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "c" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "c" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "c" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "v" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "v" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "v" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "v" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "b" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "b" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "b" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "b" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "y" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "y" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "y" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "y" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "u" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "u" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "u" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "u" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "i" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "i" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "i" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "i" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "o" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "o" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "o" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "o" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "p" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "p" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "p" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "p" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "h" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "h" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "h" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "h" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "k" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "k" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "k" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "k" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "l" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "l" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "l" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "l" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "semicolon" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "semicolon" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "semicolon" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "semicolon" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "n" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "n" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "n" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "n" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "m" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "m" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "m" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "m" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "comma" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "comma" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "comma" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "comma" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "period" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "period" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "period" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "period" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "slash" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "slash" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "slash" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "slash" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "s",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "parameters": {
-                                    "basic.to_if_alone_timeout_milliseconds": 200,
-                                    "basic.to_if_held_down_threshold_milliseconds": 200
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "left_option",
-                                        "lazy": true
-                                    }
-                                ],
-                                "to_if_alone": [{ "key_code": "s" }],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "q" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "q" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "q" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "q" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "w" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "w" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "w" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "w" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "e" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "e" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "e" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "e" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "r" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "r" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "r" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "r" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "t" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "t" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "t" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "t" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "a" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "a" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "a" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "a" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "g" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "g" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "g" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "g" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "z" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "z" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "z" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "z" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "x" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "x" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "x" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "x" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "c" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "c" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "c" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "c" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "v" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "v" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "v" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "v" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "b" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "b" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "b" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "b" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "y" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "y" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "y" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "y" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "u" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "u" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "u" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "u" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "i" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "i" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "i" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "i" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "o" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "o" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "o" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "o" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "p" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "p" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "p" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "p" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "h" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "h" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "h" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "h" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "k" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "k" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "k" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "k" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "l" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "l" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "l" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "l" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "semicolon" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "semicolon" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "semicolon" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "semicolon" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "n" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "n" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "n" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "n" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "m" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "m" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "m" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "m" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "comma" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "comma" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "comma" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "comma" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "period" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "period" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "period" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "period" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "slash" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "slash" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "slash" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "slash" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "d",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "parameters": {
-                                    "basic.to_if_alone_timeout_milliseconds": 200,
-                                    "basic.to_if_held_down_threshold_milliseconds": 200
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "left_control",
-                                        "lazy": true
-                                    }
-                                ],
-                                "to_if_alone": [{ "key_code": "d" }],
-                                "type": "basic"
-                            }
-                        ]
-                    },
-                    {
-                        "description": "Home Row Mods (Shift on J)",
-                        "manipulators": [
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "q" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "q" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "q" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "q" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "w" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "w" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "w" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "w" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "e" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "e" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "e" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "e" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "r" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "r" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "r" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "r" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "t" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "t" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "t" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "t" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "a" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "a" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "a" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "a" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "s" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "s" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "s" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "s" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "d" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "d" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "d" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "d" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "f" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "f" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "f" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "f" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "g" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "g" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "g" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "g" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "z" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "z" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "z" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "z" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "x" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "x" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "x" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "x" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "c" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "c" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "c" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "c" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "v" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "v" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "v" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "v" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "b" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "b" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "b" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "b" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "y" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "y" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "y" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "y" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "u" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "u" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "u" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "u" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "i" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "i" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "i" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "i" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "o" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "o" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "o" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "o" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "p" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "p" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "p" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "p" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "h" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "h" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "h" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "h" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "k" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "k" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "k" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "k" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "l" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "l" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "l" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "l" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "semicolon" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "semicolon" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "semicolon" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "semicolon" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "n" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "n" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "n" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "n" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "m" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "m" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "m" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "m" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "comma" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "comma" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "comma" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "comma" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "period" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "period" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "period" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "period" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "j" },
-                                        { "key_code": "slash" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "j" },
-                                    { "key_code": "slash" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "simultaneous": [
-                                        { "key_code": "slash" },
-                                        { "key_code": "j" }
-                                    ],
-                                    "simultaneous_options": { "key_down_order": "strict" }
-                                },
-                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
-                                "to": [
-                                    { "key_code": "slash" },
-                                    { "key_code": "j" }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
-                                        "bundle_identifiers": [
-                                            "^com\\.apple\\.Terminal$",
-                                            "^com\\.googlecode\\.iterm2$",
-                                            "^org\\.alacritty$",
-                                            "^com\\.github\\.wez\\.wezterm$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.google\\.Chrome$",
-                                            "^dev\\.zed\\.Zed$",
-                                            "^com\\.todesktop\\.230313mzl4w4u92$"
-                                        ],
-                                        "type": "frontmost_application_unless"
-                                    }
-                                ],
-                                "from": {
-                                    "key_code": "j",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "parameters": {
-                                    "basic.to_if_alone_timeout_milliseconds": 200,
-                                    "basic.to_if_held_down_threshold_milliseconds": 200
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "right_shift",
-                                        "lazy": true
-                                    }
-                                ],
-                                "to_if_alone": [{ "key_code": "j" }],
-                                "type": "basic"
-                            }
-                        ]
-                    },
-                    {
-                        "description": "Tap CMD to toggle Kana/Eisuu",
-                        "manipulators": [
-                            {
-                                "from": {
-                                    "key_code": "left_command",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "parameters": { "basic.to_if_held_down_threshold_milliseconds": 100 },
-                                "to": [
-                                    {
-                                        "key_code": "left_command",
-                                        "lazy": true
-                                    }
-                                ],
-                                "to_if_alone": [{ "key_code": "japanese_eisuu" }],
-                                "to_if_held_down": [{ "key_code": "left_command" }],
-                                "type": "basic"
-                            },
-                            {
-                                "from": {
-                                    "key_code": "right_command",
-                                    "modifiers": { "optional": ["any"] }
-                                },
-                                "parameters": { "basic.to_if_held_down_threshold_milliseconds": 100 },
-                                "to": [
-                                    {
-                                        "key_code": "right_command",
-                                        "lazy": true
-                                    }
-                                ],
-                                "to_if_alone": [{ "key_code": "japanese_kana" }],
-                                "to_if_held_down": [{ "key_code": "right_command" }],
-                                "type": "basic"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "devices": [
-                {
-                    "identifiers": { "is_keyboard": true },
-                    "simple_modifications": [
-                        {
-                            "from": { "key_code": "caps_lock" },
-                            "to": [{ "key_code": "left_control" }]
-                        }
+  "profiles": [
+    {
+      "complex_modifications": {
+        "rules": [
+          {
+            "description": "Terminal Ctrl tap-hold + tmux IME bypass",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "left_control",
+                  "modifiers": {
+                    "optional": [
+                      "any"
                     ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "left_control",
+                    "lazy": true
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "left_control",
+                    "hold_down_milliseconds": 300
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_alone_timeout_milliseconds": 300
+                },
+                "conditions": [
+                  {
+                    "type": "frontmost_application_if",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "b",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "japanese_eisuu"
+                  },
+                  {
+                    "key_code": "b",
+                    "modifiers": [
+                      "left_control"
+                    ]
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_if",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "Ctrl navigation (hjkl / word / page)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "comma",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "left_arrow",
+                    "modifiers": [
+                      "left_option"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "period",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "right_arrow",
+                    "modifiers": [
+                      "left_option"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "w",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "page_up"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "v",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "page_down"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "h",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "left_arrow"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "j",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "down_arrow"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "k",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "up_arrow"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "l",
+                  "modifiers": {
+                    "mandatory": [
+                      "left_control"
+                    ],
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "right_arrow"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "Home Row Mods (Cmd+Opt+Ctrl on ;)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "semicolon",
+                  "modifiers": {
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "right_command",
+                    "modifiers": [
+                      "right_control",
+                      "right_option"
+                    ],
+                    "lazy": true
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "semicolon"
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_alone_timeout_milliseconds": 200,
+                  "basic.to_if_held_down_threshold_milliseconds": 200
                 }
-            ],
-            "name": "Default profile",
-            "selected": true,
-            "virtual_hid_keyboard": { "keyboard_type_v2": "ansi" }
+              }
+            ]
+          },
+          {
+            "description": "Home Row Mods (Shift on F, Opt on S, Ctrl on D)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "q"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "q"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "q"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "q"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "w"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "w"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "w"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "w"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "e"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "e"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "e"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "e"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "r"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "r"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "r"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "r"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "t"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "t"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "t"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "t"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "a"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "a"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "a"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "a"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "g"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "g"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "g"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "g"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "z"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "z"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "z"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "z"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "x"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "x"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "x"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "x"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "c"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "c"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "c"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "c"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "v"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "v"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "v"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "v"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "b"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "b"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "b"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "b"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "y"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "y"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "y"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "y"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "u"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "u"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "u"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "u"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "i"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "i"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "i"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "i"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "o"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "o"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "o"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "o"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "p"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "p"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "p"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "p"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "h"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "h"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "h"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "h"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "k"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "k"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "k"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "k"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "l"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "l"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "l"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "l"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "semicolon"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "semicolon"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "semicolon"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "semicolon"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "n"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "n"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "n"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "n"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "m"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "m"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "m"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "m"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "comma"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "comma"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "comma"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "comma"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "period"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "period"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "period"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "period"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "slash"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "slash"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "slash"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "slash"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "f",
+                  "modifiers": {
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "left_shift",
+                    "lazy": true
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "f"
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_alone_timeout_milliseconds": 200,
+                  "basic.to_if_held_down_threshold_milliseconds": 200
+                }
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "q"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "q"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "q"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "q"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "w"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "w"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "w"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "w"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "e"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "e"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "e"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "e"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "r"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "r"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "r"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "r"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "t"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "t"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "t"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "t"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "a"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "a"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "a"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "a"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "g"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "g"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "g"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "g"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "z"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "z"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "z"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "z"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "x"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "x"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "x"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "x"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "c"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "c"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "c"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "c"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "v"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "v"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "v"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "v"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "b"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "b"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "b"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "b"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "y"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "y"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "y"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "y"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "u"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "u"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "u"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "u"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "i"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "i"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "i"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "i"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "o"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "o"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "o"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "o"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "p"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "p"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "p"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "p"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "h"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "h"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "h"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "h"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "k"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "k"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "k"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "k"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "l"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "l"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "l"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "l"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "semicolon"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "semicolon"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "semicolon"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "semicolon"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "n"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "n"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "n"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "n"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "m"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "m"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "m"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "m"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "comma"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "comma"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "comma"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "comma"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "period"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "period"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "period"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "period"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "slash"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "slash"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "slash"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "slash"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "s",
+                  "modifiers": {
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "left_option",
+                    "lazy": true
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "s"
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_alone_timeout_milliseconds": 200,
+                  "basic.to_if_held_down_threshold_milliseconds": 200
+                }
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "q"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "q"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "q"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "q"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "w"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "w"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "w"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "w"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "e"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "e"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "e"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "e"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "r"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "r"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "r"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "r"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "t"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "t"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "t"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "t"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "a"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "a"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "a"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "a"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "g"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "g"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "g"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "g"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "z"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "z"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "z"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "z"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "x"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "x"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "x"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "x"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "c"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "c"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "c"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "c"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "v"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "v"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "v"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "v"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "b"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "b"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "b"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "b"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "y"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "y"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "y"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "y"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "u"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "u"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "u"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "u"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "i"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "i"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "i"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "i"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "o"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "o"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "o"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "o"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "p"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "p"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "p"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "p"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "h"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "h"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "h"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "h"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "k"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "k"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "k"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "k"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "l"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "l"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "l"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "l"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "semicolon"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "semicolon"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "semicolon"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "semicolon"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "n"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "n"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "n"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "n"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "m"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "m"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "m"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "m"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "comma"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "comma"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "comma"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "comma"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "period"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "period"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "period"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "period"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "slash"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "slash"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "slash"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "slash"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "d",
+                  "modifiers": {
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "left_control",
+                    "lazy": true
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "d"
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_alone_timeout_milliseconds": 200,
+                  "basic.to_if_held_down_threshold_milliseconds": 200
+                }
+              }
+            ]
+          },
+          {
+            "description": "Home Row Mods (Shift on J)",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "q"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "q"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "q"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "q"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "w"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "w"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "w"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "w"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "e"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "e"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "e"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "e"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "r"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "r"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "r"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "r"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "t"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "t"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "t"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "t"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "a"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "a"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "a"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "a"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "s"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "s"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "s"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "d"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "d"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "d"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "f"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "f"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "f"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "g"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "g"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "g"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "g"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "z"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "z"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "z"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "z"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "x"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "x"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "x"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "x"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "c"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "c"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "c"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "c"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "v"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "v"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "v"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "v"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "b"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "b"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "b"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "b"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "y"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "y"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "y"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "y"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "u"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "u"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "u"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "u"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "i"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "i"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "i"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "i"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "o"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "o"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "o"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "o"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "p"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "p"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "p"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "p"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "h"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "h"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "h"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "h"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "k"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "k"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "k"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "k"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "l"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "l"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "l"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "l"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "semicolon"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "semicolon"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "semicolon"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "semicolon"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "n"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "n"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "n"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "n"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "m"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "m"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "m"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "m"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "comma"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "comma"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "comma"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "comma"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "period"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "period"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "period"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "period"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "j"
+                    },
+                    {
+                      "key_code": "slash"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "j"
+                  },
+                  {
+                    "key_code": "slash"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "simultaneous": [
+                    {
+                      "key_code": "slash"
+                    },
+                    {
+                      "key_code": "j"
+                    }
+                  ],
+                  "simultaneous_options": {
+                    "key_down_order": "strict"
+                  }
+                },
+                "parameters": {
+                  "basic.simultaneous_threshold_milliseconds": 180
+                },
+                "to": [
+                  {
+                    "key_code": "slash"
+                  },
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "j",
+                  "modifiers": {
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "right_shift",
+                    "lazy": true
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "j"
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_alone_timeout_milliseconds": 200,
+                  "basic.to_if_held_down_threshold_milliseconds": 200
+                },
+                "conditions": [
+                  {
+                    "type": "frontmost_application_unless",
+                    "bundle_identifiers": [
+                      "^com\\.apple\\.Terminal$",
+                      "^com\\.googlecode\\.iterm2$",
+                      "^org\\.alacritty$",
+                      "^com\\.github\\.wez\\.wezterm$",
+                      "^com\\.mitchellh\\.ghostty$",
+                      "^net\\.kovidgoyal\\.kitty$",
+                      "^com\\.google\\.Chrome$",
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.todesktop\\.230313mzl4w4u92$"
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "description": "Tap CMD to toggle Kana/Eisuu",
+            "manipulators": [
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "left_command",
+                  "modifiers": {
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "left_command",
+                    "lazy": true
+                  }
+                ],
+                "to_if_held_down": [
+                  {
+                    "key_code": "left_command"
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "japanese_eisuu"
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_held_down_threshold_milliseconds": 100
+                }
+              },
+              {
+                "type": "basic",
+                "from": {
+                  "key_code": "right_command",
+                  "modifiers": {
+                    "optional": [
+                      "any"
+                    ]
+                  }
+                },
+                "to": [
+                  {
+                    "key_code": "right_command",
+                    "lazy": true
+                  }
+                ],
+                "to_if_held_down": [
+                  {
+                    "key_code": "right_command"
+                  }
+                ],
+                "to_if_alone": [
+                  {
+                    "key_code": "japanese_kana"
+                  }
+                ],
+                "parameters": {
+                  "basic.to_if_held_down_threshold_milliseconds": 100
+                }
+              }
+            ]
+          }
+        ],
+        "parameters": {
+          "basic.to_if_alone_timeout_milliseconds": 1000,
+          "basic.to_if_held_down_threshold_milliseconds": 500,
+          "basic.to_delayed_action_delay_milliseconds": 500,
+          "basic.simultaneous_threshold_milliseconds": 50,
+          "mouse_motion_to_scroll.speed": 100
         }
-    ]
+      },
+      "devices": [
+        {
+          "identifiers": {
+            "is_keyboard": true
+          },
+          "simple_modifications": [
+            {
+              "from": {
+                "key_code": "caps_lock"
+              },
+              "to": [
+                {
+                  "key_code": "left_control"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "name": "Default profile",
+      "selected": true,
+      "virtual_hid_keyboard": {
+        "keyboard_type_v2": "ansi"
+      }
+    }
+  ]
 }

--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -1,7707 +1,4762 @@
 {
-  "profiles": [
-    {
-      "complex_modifications": {
-        "rules": [
-          {
-            "description": "Terminal Ctrl tap-hold + tmux IME bypass",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "left_control",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "left_control",
-                    "lazy": true
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "left_control",
-                    "hold_down_milliseconds": 300
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_alone_timeout_milliseconds": 300
-                },
-                "conditions": [
-                  {
-                    "type": "frontmost_application_if",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "b",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "japanese_eisuu"
-                  },
-                  {
-                    "key_code": "b",
-                    "modifiers": [
-                      "left_control"
-                    ]
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_if",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "description": "Ctrl navigation (hjkl / word / page)",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "comma",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "left_arrow",
-                    "modifiers": [
-                      "left_option"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "period",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "right_arrow",
-                    "modifiers": [
-                      "left_option"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "w",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "page_up"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "v",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "page_down"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "h",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "left_arrow"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "j",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "down_arrow"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "k",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "up_arrow"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "l",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "right_arrow"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "description": "Home Row Mods (Opt+Shift on ;)",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "semicolon",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "right_option",
-                    "modifiers": [
-                      "right_shift"
-                    ],
-                    "lazy": true
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "semicolon"
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_alone_timeout_milliseconds": 200,
-                  "basic.to_if_held_down_threshold_milliseconds": 200
-                }
-              }
-            ]
-          },
-          {
-            "description": "Home Row Mods (Shift on F, Opt on S, Ctrl on D)",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "q"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "q"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "q"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "q"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "w"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "w"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "w"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "w"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "e"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "e"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "e"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "e"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "r"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "r"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "r"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "r"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "t"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "t"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "t"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "t"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "a"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "a"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "a"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "a"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "g"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "g"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "g"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "g"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "z"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "z"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "z"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "z"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "x"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "x"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "x"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "x"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "c"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "c"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "c"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "c"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "v"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "v"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "v"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "v"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "b"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "b"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "b"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "b"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "y"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "y"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "y"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "y"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "u"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "u"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "u"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "u"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "i"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "i"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "i"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "i"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "o"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "o"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "o"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "o"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "p"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "p"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "p"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "p"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "h"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "h"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "h"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "h"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "k"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "k"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "k"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "k"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "l"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "l"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "l"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "l"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "semicolon"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "semicolon"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "semicolon"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "semicolon"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "n"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "n"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "n"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "n"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "m"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "m"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "m"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "m"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "comma"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "comma"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "comma"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "comma"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "period"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "period"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "period"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "period"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "slash"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "slash"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "slash"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "slash"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "f",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "left_shift",
-                    "lazy": true
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "f"
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_alone_timeout_milliseconds": 200,
-                  "basic.to_if_held_down_threshold_milliseconds": 200
-                }
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "q"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "q"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "q"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "q"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "w"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "w"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "w"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "w"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "e"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "e"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "e"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "e"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "r"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "r"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "r"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "r"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "t"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "t"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "t"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "t"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "a"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "a"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "a"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "a"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "g"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "g"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "g"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "g"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "z"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "z"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "z"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "z"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "x"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "x"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "x"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "x"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "c"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "c"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "c"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "c"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "v"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "v"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "v"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "v"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "b"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "b"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "b"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "b"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "y"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "y"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "y"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "y"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "u"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "u"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "u"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "u"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "i"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "i"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "i"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "i"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "o"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "o"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "o"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "o"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "p"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "p"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "p"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "p"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "h"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "h"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "h"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "h"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "k"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "k"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "k"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "k"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "l"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "l"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "l"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "l"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "semicolon"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "semicolon"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "semicolon"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "semicolon"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "n"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "n"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "n"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "n"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "m"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "m"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "m"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "m"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "comma"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "comma"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "comma"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "comma"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "period"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "period"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "period"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "period"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "slash"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "slash"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "slash"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "slash"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "s",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "left_option",
-                    "lazy": true
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "s"
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_alone_timeout_milliseconds": 200,
-                  "basic.to_if_held_down_threshold_milliseconds": 200
-                }
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "q"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "q"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "q"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "q"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "w"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "w"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "w"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "w"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "e"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "e"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "e"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "e"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "r"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "r"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "r"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "r"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "t"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "t"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "t"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "t"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "a"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "a"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "a"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "a"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "g"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "g"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "g"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "g"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "z"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "z"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "z"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "z"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "x"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "x"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "x"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "x"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "c"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "c"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "c"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "c"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "v"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "v"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "v"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "v"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "b"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "b"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "b"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "b"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "y"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "y"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "y"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "y"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "u"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "u"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "u"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "u"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "i"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "i"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "i"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "i"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "o"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "o"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "o"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "o"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "p"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "p"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "p"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "p"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "h"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "h"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "h"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "h"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "k"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "k"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "k"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "k"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "l"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "l"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "l"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "l"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "semicolon"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "semicolon"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "semicolon"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "semicolon"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "n"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "n"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "n"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "n"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "m"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "m"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "m"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "m"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "comma"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "comma"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "comma"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "comma"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "period"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "period"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "period"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "period"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "slash"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "slash"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "slash"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "slash"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "d",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "left_control",
-                    "lazy": true
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "d"
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_alone_timeout_milliseconds": 200,
-                  "basic.to_if_held_down_threshold_milliseconds": 200
-                }
-              }
-            ]
-          },
-          {
-            "description": "Home Row Mods (Shift on J)",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "q"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "q"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "q"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "q"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "w"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "w"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "w"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "w"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "e"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "e"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "e"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "e"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "r"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "r"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "r"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "r"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "t"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "t"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "t"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "t"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "a"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "a"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "a"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "a"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "s"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "s"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "s"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "s"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "d"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "d"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "d"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "d"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "f"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "f"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "f"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "f"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "g"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "g"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "g"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "g"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "z"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "z"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "z"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "z"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "x"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "x"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "x"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "x"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "c"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "c"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "c"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "c"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "v"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "v"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "v"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "v"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "b"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "b"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "b"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "b"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "y"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "y"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "y"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "y"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "u"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "u"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "u"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "u"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "i"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "i"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "i"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "i"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "o"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "o"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "o"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "o"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "p"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "p"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "p"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "p"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "h"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "h"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "h"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "h"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "k"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "k"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "k"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "k"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "l"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "l"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "l"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "l"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "semicolon"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "semicolon"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "semicolon"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "semicolon"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "n"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "n"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "n"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "n"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "m"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "m"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "m"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "m"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "comma"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "comma"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "comma"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "comma"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "period"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "period"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "period"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "period"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "j"
-                    },
-                    {
-                      "key_code": "slash"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "j"
-                  },
-                  {
-                    "key_code": "slash"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "simultaneous": [
-                    {
-                      "key_code": "slash"
-                    },
-                    {
-                      "key_code": "j"
-                    }
-                  ],
-                  "simultaneous_options": {
-                    "key_down_order": "strict"
-                  }
-                },
-                "parameters": {
-                  "basic.simultaneous_threshold_milliseconds": 180
-                },
-                "to": [
-                  {
-                    "key_code": "slash"
-                  },
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "j",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "right_shift",
-                    "lazy": true
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "j"
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_alone_timeout_milliseconds": 200,
-                  "basic.to_if_held_down_threshold_milliseconds": 200
-                },
-                "conditions": [
-                  {
-                    "type": "frontmost_application_unless",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$",
-                      "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$",
-                      "^com\\.todesktop\\.230313mzl4w4u92$"
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "description": "Tap CMD to toggle Kana/Eisuu",
-            "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "left_command",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "left_command",
-                    "lazy": true
-                  }
-                ],
-                "to_if_held_down": [
-                  {
-                    "key_code": "left_command"
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "japanese_eisuu"
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_held_down_threshold_milliseconds": 100
-                }
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "right_command",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "right_command",
-                    "lazy": true
-                  }
-                ],
-                "to_if_held_down": [
-                  {
-                    "key_code": "right_command"
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "japanese_kana"
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_held_down_threshold_milliseconds": 100
-                }
-              }
-            ]
-          }
-        ],
-        "parameters": {
-          "basic.to_if_alone_timeout_milliseconds": 1000,
-          "basic.to_if_held_down_threshold_milliseconds": 500,
-          "basic.to_delayed_action_delay_milliseconds": 500,
-          "basic.simultaneous_threshold_milliseconds": 50,
-          "mouse_motion_to_scroll.speed": 100
-        }
-      },
-      "devices": [
+    "profiles": [
         {
-          "identifiers": {
-            "is_keyboard": true
-          },
-          "simple_modifications": [
-            {
-              "from": {
-                "key_code": "caps_lock"
-              },
-              "to": [
+            "complex_modifications": {
+                "rules": [
+                    {
+                        "description": "Terminal Ctrl tap-hold + tmux IME bypass",
+                        "manipulators": [
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$"
+                                        ],
+                                        "type": "frontmost_application_if"
+                                    }
+                                ],
+                                "from": {
+                                    "key_code": "left_control",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": { "basic.to_if_alone_timeout_milliseconds": 300 },
+                                "to": [
+                                    {
+                                        "key_code": "left_control",
+                                        "lazy": true
+                                    }
+                                ],
+                                "to_if_alone": [
+                                    {
+                                        "hold_down_milliseconds": 300,
+                                        "key_code": "left_control"
+                                    }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$"
+                                        ],
+                                        "type": "frontmost_application_if"
+                                    }
+                                ],
+                                "from": {
+                                    "key_code": "b",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [
+                                    { "key_code": "japanese_eisuu" },
+                                    {
+                                        "key_code": "b",
+                                        "modifiers": ["left_control"]
+                                    }
+                                ],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Ctrl navigation (hjkl / word / page)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "comma",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_arrow",
+                                        "modifiers": ["left_option"]
+                                    }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "period",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "right_arrow",
+                                        "modifiers": ["left_option"]
+                                    }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "w",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [{ "key_code": "page_up" }],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "v",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [{ "key_code": "page_down" }],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "h",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [{ "key_code": "left_arrow" }],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "j",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [{ "key_code": "down_arrow" }],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "k",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [{ "key_code": "up_arrow" }],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "l",
+                                    "modifiers": {
+                                        "mandatory": ["left_control"],
+                                        "optional": ["any"]
+                                    }
+                                },
+                                "to": [{ "key_code": "right_arrow" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Home Row Mods (Cmd+Opt+Ctrl on ;)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "semicolon",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_if_alone_timeout_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "right_command",
+                                        "lazy": true,
+                                        "modifiers": ["right_control", "right_option"]
+                                    }
+                                ],
+                                "to_if_alone": [{ "key_code": "semicolon" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Home Row Mods (Shift on F, Opt on S, Ctrl on D)",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "q" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "q" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "q" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "q" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "w" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "w" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "w" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "w" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "e" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "e" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "e" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "e" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "r" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "r" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "r" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "r" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "t" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "t" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "t" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "t" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "a" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "a" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "a" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "a" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "g" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "g" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "g" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "g" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "z" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "z" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "z" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "z" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "x" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "x" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "x" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "x" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "c" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "c" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "c" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "c" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "v" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "v" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "v" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "v" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "b" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "b" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "b" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "b" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "y" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "y" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "y" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "y" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "u" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "u" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "u" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "u" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "i" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "i" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "i" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "i" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "o" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "o" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "o" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "o" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "p" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "p" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "p" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "p" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "h" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "h" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "h" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "h" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "k" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "k" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "k" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "k" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "l" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "l" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "l" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "l" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "semicolon" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "semicolon" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "semicolon" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "semicolon" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "n" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "n" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "n" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "n" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "m" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "m" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "m" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "m" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "comma" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "comma" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "comma" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "comma" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "period" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "period" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "period" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "period" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "slash" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "slash" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "slash" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "slash" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "f",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_if_alone_timeout_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_shift",
+                                        "lazy": true
+                                    }
+                                ],
+                                "to_if_alone": [{ "key_code": "f" }],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "q" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "q" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "q" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "q" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "w" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "w" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "w" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "w" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "e" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "e" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "e" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "e" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "r" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "r" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "r" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "r" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "t" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "t" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "t" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "t" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "a" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "a" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "a" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "a" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "g" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "g" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "g" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "g" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "z" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "z" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "z" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "z" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "x" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "x" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "x" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "x" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "c" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "c" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "c" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "c" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "v" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "v" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "v" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "v" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "b" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "b" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "b" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "b" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "y" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "y" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "y" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "y" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "u" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "u" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "u" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "u" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "i" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "i" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "i" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "i" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "o" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "o" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "o" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "o" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "p" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "p" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "p" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "p" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "h" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "h" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "h" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "h" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "k" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "k" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "k" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "k" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "l" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "l" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "l" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "l" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "semicolon" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "semicolon" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "semicolon" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "semicolon" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "n" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "n" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "n" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "n" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "m" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "m" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "m" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "m" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "comma" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "comma" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "comma" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "comma" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "period" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "period" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "period" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "period" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "slash" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "slash" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "slash" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "slash" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "s",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_if_alone_timeout_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_option",
+                                        "lazy": true
+                                    }
+                                ],
+                                "to_if_alone": [{ "key_code": "s" }],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "q" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "q" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "q" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "q" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "w" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "w" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "w" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "w" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "e" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "e" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "e" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "e" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "r" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "r" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "r" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "r" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "t" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "t" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "t" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "t" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "a" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "a" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "a" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "a" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "g" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "g" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "g" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "g" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "z" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "z" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "z" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "z" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "x" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "x" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "x" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "x" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "c" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "c" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "c" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "c" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "v" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "v" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "v" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "v" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "b" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "b" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "b" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "b" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "y" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "y" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "y" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "y" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "u" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "u" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "u" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "u" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "i" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "i" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "i" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "i" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "o" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "o" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "o" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "o" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "p" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "p" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "p" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "p" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "h" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "h" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "h" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "h" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "k" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "k" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "k" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "k" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "l" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "l" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "l" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "l" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "semicolon" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "semicolon" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "semicolon" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "semicolon" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "n" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "n" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "n" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "n" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "m" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "m" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "m" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "m" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "comma" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "comma" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "comma" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "comma" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "period" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "period" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "period" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "period" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "slash" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "slash" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "slash" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "slash" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "d",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_if_alone_timeout_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "left_control",
+                                        "lazy": true
+                                    }
+                                ],
+                                "to_if_alone": [{ "key_code": "d" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Home Row Mods (Shift on J)",
+                        "manipulators": [
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "q" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "q" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "q" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "q" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "w" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "w" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "w" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "w" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "e" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "e" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "e" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "e" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "r" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "r" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "r" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "r" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "t" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "t" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "t" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "t" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "a" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "a" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "a" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "a" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "s" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "s" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "s" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "s" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "d" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "d" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "d" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "d" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "f" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "f" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "f" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "f" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "g" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "g" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "g" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "g" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "z" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "z" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "z" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "z" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "x" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "x" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "x" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "x" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "c" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "c" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "c" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "c" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "v" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "v" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "v" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "v" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "b" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "b" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "b" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "b" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "y" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "y" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "y" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "y" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "u" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "u" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "u" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "u" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "i" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "i" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "i" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "i" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "o" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "o" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "o" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "o" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "p" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "p" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "p" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "p" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "h" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "h" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "h" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "h" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "k" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "k" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "k" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "k" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "l" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "l" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "l" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "l" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "semicolon" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "semicolon" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "semicolon" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "semicolon" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "n" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "n" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "n" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "n" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "m" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "m" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "m" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "m" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "comma" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "comma" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "comma" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "comma" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "period" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "period" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "period" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "period" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "j" },
+                                        { "key_code": "slash" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "j" },
+                                    { "key_code": "slash" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "simultaneous": [
+                                        { "key_code": "slash" },
+                                        { "key_code": "j" }
+                                    ],
+                                    "simultaneous_options": { "key_down_order": "strict" }
+                                },
+                                "parameters": { "basic.simultaneous_threshold_milliseconds": 180 },
+                                "to": [
+                                    { "key_code": "slash" },
+                                    { "key_code": "j" }
+                                ],
+                                "type": "basic"
+                            },
+                            {
+                                "conditions": [
+                                    {
+                                        "bundle_identifiers": [
+                                            "^com\\.apple\\.Terminal$",
+                                            "^com\\.googlecode\\.iterm2$",
+                                            "^org\\.alacritty$",
+                                            "^com\\.github\\.wez\\.wezterm$",
+                                            "^com\\.mitchellh\\.ghostty$",
+                                            "^net\\.kovidgoyal\\.kitty$",
+                                            "^com\\.google\\.Chrome$",
+                                            "^dev\\.zed\\.Zed$",
+                                            "^com\\.todesktop\\.230313mzl4w4u92$"
+                                        ],
+                                        "type": "frontmost_application_unless"
+                                    }
+                                ],
+                                "from": {
+                                    "key_code": "j",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": {
+                                    "basic.to_if_alone_timeout_milliseconds": 200,
+                                    "basic.to_if_held_down_threshold_milliseconds": 200
+                                },
+                                "to": [
+                                    {
+                                        "key_code": "right_shift",
+                                        "lazy": true
+                                    }
+                                ],
+                                "to_if_alone": [{ "key_code": "j" }],
+                                "type": "basic"
+                            }
+                        ]
+                    },
+                    {
+                        "description": "Tap CMD to toggle Kana/Eisuu",
+                        "manipulators": [
+                            {
+                                "from": {
+                                    "key_code": "left_command",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": { "basic.to_if_held_down_threshold_milliseconds": 100 },
+                                "to": [
+                                    {
+                                        "key_code": "left_command",
+                                        "lazy": true
+                                    }
+                                ],
+                                "to_if_alone": [{ "key_code": "japanese_eisuu" }],
+                                "to_if_held_down": [{ "key_code": "left_command" }],
+                                "type": "basic"
+                            },
+                            {
+                                "from": {
+                                    "key_code": "right_command",
+                                    "modifiers": { "optional": ["any"] }
+                                },
+                                "parameters": { "basic.to_if_held_down_threshold_milliseconds": 100 },
+                                "to": [
+                                    {
+                                        "key_code": "right_command",
+                                        "lazy": true
+                                    }
+                                ],
+                                "to_if_alone": [{ "key_code": "japanese_kana" }],
+                                "to_if_held_down": [{ "key_code": "right_command" }],
+                                "type": "basic"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "devices": [
                 {
-                  "key_code": "left_control"
+                    "identifiers": { "is_keyboard": true },
+                    "simple_modifications": [
+                        {
+                            "from": { "key_code": "caps_lock" },
+                            "to": [{ "key_code": "left_control" }]
+                        }
+                    ]
                 }
-              ]
-            }
-          ]
+            ],
+            "name": "Default profile",
+            "selected": true,
+            "virtual_hid_keyboard": { "keyboard_type_v2": "ansi" }
         }
-      ],
-      "name": "Default profile",
-      "selected": true,
-      "virtual_hid_keyboard": {
-        "keyboard_type_v2": "ansi"
-      }
-    }
-  ]
+    ]
 }

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -125,11 +125,13 @@ writeToProfile('Default profile', [
     ),
   ]),
 
-  rule('Home Row Mods (Opt+Shift on ;)').manipulators([
+  // Shift を含めると macOS の中国語変換サービス (⌃⌥⇧⌘C / ⌃⌥⇧⌘V) と衝突するため
+  // ⌘⌥⌃ に留める。Cmd を含むことが Secure Input 固着時のホットキー生存条件。
+  rule('Home Row Mods (Cmd+Opt+Ctrl on ;)').manipulators([
     map({ key_code: 'semicolon', modifiers: { optional: ['any'] } })
       .to({
-        key_code: 'right_option',
-        modifiers: ['right_shift'],
+        key_code: 'right_command',
+        modifiers: ['right_control', 'right_option'],
         lazy: true,
       })
       .toIfAlone({ key_code: 'semicolon' })

--- a/.config/karabiner/package.json
+++ b/.config/karabiner/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun run karabiner.ts && bun run reload && bun run sync",
+    "build": "bun run karabiner.ts && bun run sync && bun run reload",
     "sync": "cmp -s ~/.config/karabiner/karabiner.json ./karabiner.json || cp ~/.config/karabiner/karabiner.json ./karabiner.json",
     "watch": "bun run --watch karabiner.ts",
     "reload": "if [ -x \"/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli\" ]; then \"/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli\" --select-profile 'Default profile'; fi"

--- a/.config/karabiner/package.json
+++ b/.config/karabiner/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "bun run karabiner.ts && bun run reload && bun run sync",
-    "sync": "cp ~/.config/karabiner/karabiner.json ./karabiner.json",
+    "sync": "cmp -s ~/.config/karabiner/karabiner.json ./karabiner.json || cp ~/.config/karabiner/karabiner.json ./karabiner.json",
     "watch": "bun run --watch karabiner.ts",
     "reload": "if [ -x \"/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli\" ]; then \"/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli\" --select-profile 'Default profile'; fi"
   },

--- a/.config/karabiner/package.json
+++ b/.config/karabiner/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun run karabiner.ts && bun run reload",
+    "build": "bun run karabiner.ts && bun run reload && bun run sync",
+    "sync": "cp ~/.config/karabiner/karabiner.json ./karabiner.json",
     "watch": "bun run --watch karabiner.ts",
     "reload": "if [ -x \"/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli\" ]; then \"/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_cli\" --select-profile 'Default profile'; fi"
   },


### PR DESCRIPTION
## Background / 背景

Raycast のホットキーは `;` ホールド（Karabiner で Opt+Shift に変換）をプレフィックスにしていたが、ghostty の Secure Input 固着バグ発生時、macOS が Cmd を含まないグローバルホットキーを無効化するため全滅していた（#136 の postmortem 参照）。Cmd を含む修飾キー組み合わせに移行することで、固着時もホットキーが生存する構成にする。

## Changes / 変更内容

- `;` ホールドの変換先を Opt+Shift → **Cmd+Opt+Ctrl (⌘⌥⌃)** に変更（タップで `;` を打つ挙動は維持）
  - フル Hyper (⌘⌥⌃⇧) にしなかったのは、macOS の中国語変換サービスが ⌃⌥⇧⌘C / ⌃⌥⇧⌘V を占有しており Shift 込みだと衝突するため
- `HRM.md` のチートシートを更新
- `package.json` の `build` に `sync` ステップを追加: `writeToProfile` は atomic write (temp + rename) のためビルドごとに link.sh の symlink が実ファイルに置き換わり、repo 側 `karabiner.json` が黙って stale になっていた。ビルド出力を repo へ cp で書き戻して常に一致させる

なお `karabiner.json` の diff が巨大に見えるのは生成フォーマット（キー順・デフォルト parameters ブロック有無）の差によるもので、意味的な変更は `;` ルールのみ（sort-keys 正規化した JSON 比較で確認済み）。

## Impact scope / 影響範囲

- `;` ホールドを使う操作全般。Raycast ホットキーは ⌘⌥⌃+キー への録り直しが必要（実施・動作確認済み）
- 旧 Opt+Shift 用途（単語選択等）は `;` からは打てなくなるが、F(Shift)+S(Opt) の HRM で代替可能
- ビルドフロー: `bun run build` が「生成 → reload → repo 書き戻し」の一気通貫になる。CI (Linux runner) では reload が既存の存在チェックで no-op になるため影響なし

## Testing / 動作確認

- [x] `bun run build` 成功、`core_service.log` で `core_configuration is updated.` を確認 / build succeeds and daemon reloads config
- [x] Raycast ホットキーを ⌘⌥⌃+キー で録り直し、Chrome 起動等の発火を実機確認 / re-recorded Raycast hotkeys fire correctly
- [x] ⌘⌥⌃C が中国語変換サービスと衝突せず割り当て可能なことを確認 / no conflict with macOS Chinese conversion services
- [x] ビルド後に `~/.config/karabiner/karabiner.json` と repo 側が一致することを diff で確認 / live and repo json stay in sync after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)