### PR TITLE
docs: sync readme and claude.md with current repo state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Setup Commands
 
 ```bash
-./install.sh   # Install Homebrew, brew packages, mise, Claude Code, vim-plug
+./install.sh   # Install Homebrew, brew packages, mise, Claude Code, vim-plug, TPM, yazi plugins, Karabiner build
 ./link.sh      # Create symlinks from repo to system locations (backs up existing)
 ./settings.sh  # Configure macOS system settings (requires restart)
 ```
@@ -15,28 +15,44 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Tests run automatically via GitHub Actions on PRs and pushes to main. To run locally:
 
 ```bash
-./.github/scripts/test-install.sh   # Test install script
-./.github/scripts/test-link.sh      # Test symlink creation
-./.github/scripts/test-config.sh    # Validate config file syntax
-./.github/scripts/test-brewfile.sh  # Validate Brewfile syntax
-./.github/scripts/test-settings.sh  # Test macOS settings script
+./.github/scripts/test-install.sh          # Test install script
+./.github/scripts/test-link.sh             # Test symlink creation
+./.github/scripts/test-config.sh           # Validate config file syntax
+./.github/scripts/test-brewfile.sh         # Validate Brewfile syntax
+./.github/scripts/test-settings.sh         # Test macOS settings script
+./.github/scripts/test-karabiner-build.sh  # Verify karabiner.ts build output matches karabiner.json
 ```
 
 ## Architecture
 
 ### Core Scripts
-- `install.sh` - Installs: Homebrew → Brewfile packages → mise runtimes → Claude Code → vim-plug → TPM → yazi plugins
+- `install.sh` - Installs: Homebrew → Brewfile packages → mise runtimes → Claude Code → vim-plug → TPM → yazi plugins → Karabiner config build (bun)
 - `link.sh` - Declarative symlink management via `entries` array. Source path only = `~/{source}`, `source:destination` for custom paths. `--list` outputs all entries as `source:destination`
-- `settings.sh` - macOS defaults configuration (key repeat, trackpad settings)
+- `settings.sh` - macOS defaults configuration (key repeat, trackpad, Ctrl+Space free-up for tmux prefix, Kotoeri predictive candidates off)
 
 ### Configuration Files
-- **Shell**: `.zshrc` (main) + `.config/zsh/alias.sh` (aliases) + `.config/zsh/command.sh` (functions)
-- **Runtime**: `.mise.toml` (Node.js LTS, gcloud via mise)
-- **Terminal**: `.config/ghostty/config`
-- **Editor**: `.vimrc` (vim-plug), `.config/helix/` (Helix), `.config/cursor/` (Cursor IDE settings)
+- **Shell**: `.zshrc` / `.zshenv` (main) + `.config/zsh/` (alias.sh, command.sh, tasks.sh, hosts/)
+- **Runtime**: `.mise.toml` (Node.js LTS, bun, gcloud, terraform, biome, rust + rust-analyzer)
+- **Git**: `.gitconfig` (personal) + `.gitconfig-olta` (work, includeIf)
+- **Terminal**: `.config/ghostty/config`, `.config/tmux/tmux.conf` (→ `~/.tmux.conf`)
+- **Editor**: `.vimrc` (vim-plug), `.config/nvim/init.lua` (Neovim), `.config/helix/` (Helix), `.config/cursor/` (Cursor settings + keybindings), `.config/zed/settings.json` (Zed)
+- **Prompt/Plugins**: `.config/starship/starship.toml` (→ `~/.config/starship.toml`), `.config/sheldon/plugins.toml`
 - **File Manager**: `.config/yazi/` (yazi config + projects plugin)
 - **Search**: `.config/fd/` (fd defaults)
-- **Input**: `.config/karabiner/` (keyboard remapping)
+- **Input**: `.config/karabiner/` (keyboard remapping, TypeScript-based — see below)
+- **Claude Code**: `.config/claude/` (settings.json + commands/, symlinked to `~/.claude/`)
+
+### Karabiner (TypeScript build)
+`karabiner.json` is generated from `karabiner.ts` using the karabiner.ts library. Never edit `karabiner.json` directly — edit `karabiner.ts` and build:
+
+```bash
+cd .config/karabiner && bun run build  # generate → sync repo copy → reload profile
+```
+
+`build` regenerates the config, copies `~/.config/karabiner/karabiner.json` back into the repo (Karabiner's atomic writes break symlinks), and reloads the profile via `karabiner_cli`.
+
+### Docs
+`docs/` holds decision records and troubleshooting notes (terminal-workflow cheatsheet, cmux-vs-tmux, karabiner-vs-nix, raycast-dotfiles, secure-input-hotkey-outage). The terminal-workflow cheatsheet is symlinked for the tmux Prefix+M popup.
 
 ### Workspace Conventions
 Custom shell functions assume this structure:
@@ -61,6 +77,10 @@ gh pr merge <PR番号> --squash --delete-branch
 2. Add entry to `entries` array in `link.sh` (source path only, or `"source:destination"` if target differs)
 3. Run `./link.sh` to create symlink
 
+### Claude Code Paths
+- `.config/claude/` - files managed under `~/.claude` (settings, commands)
+- `.claude/` (repo root) - reserved for this repository's own Claude Code project settings; do not put `~/.claude` targets here
+
 ### Adding New Tools (brew vs mise)
 
 Default to Brewfile. Escalate to `.mise.toml` when any of the following applies:
@@ -70,4 +90,3 @@ Default to Brewfile. Escalate to `.mise.toml` when any of the following applies:
 - Schema URL or lockfile semantics make version pinning meaningful (e.g. `biome.json`'s `$schema`)
 
 If per-project version variance is already expected, skip brew and put it in mise from the start (don't pay the migration cost later). Run `mise registry | grep <tool>` before proposing a new tool. Prefer mise registry-native backends (aqua / asdf / core) over `npm:` fallbacks. GUI (cask) and stable system CLIs (helix, tmux, gh, fzf, etc.) stay on brew.
- 

--- a/README.md
+++ b/README.md
@@ -27,55 +27,80 @@ mise install
 
 ## What's Included
 
-### Tools & Applications
+### Tools & Applications (via Brewfile)
 - **fzf** - Command-line fuzzy finder
+- **zoxide** - Smart cd command
+- **bat** - Cat clone with syntax highlighting
 - **lsd** - Modern replacement for ls
+- **yazi** - Terminal file manager
+- **fd** - Simple, fast alternative to find
 - **sheldon** - Fast zsh plugin manager
 - **starship** - Cross-shell prompt
 - **atuin** - Shell history management
+- **helix** - Post-modern text editor
+- **neovim** - Vim-based editor (minimal config)
 - **gh** - GitHub CLI
 - **git-delta** - Syntax-highlighting pager for git
-- **zoxide** - Smart cd command
-- **bat** - Cat clone with syntax highlighting
-- **yazi** - Terminal file manager
-- **fd** - Simple, fast alternative to find
-- **helix** - Post-modern text editor
-- **tmux** - Terminal multiplexer for managing multiple sessions
-- **mise** - Runtime version manager (manages Node.js, gcloud, etc.)
+- **tmux** - Terminal multiplexer
+- **crit** - Code review tool
+- **typescript-language-server** / **yaml-language-server** - LSP servers
+- **yq** / **stern** - Kubernetes / YAML tooling
 - **ghostty** - Terminal emulator
-- **cursor** - AI-powered code editor
+- **cursor** - Code editor
+- **zed** - Code editor
 
-### Runtime Management (via mise)
-- **Node.js** - LTS version
-- **Google Cloud CLI** - Cloud development tools
+### Runtimes & Tools (via mise)
+- **Node.js** (LTS) / **Bun**
+- **Google Cloud CLI**
+- **Terraform**
+- **Biome**
+- **Rust** / **rust-analyzer**
 
 ### Configuration Files
-- `.zshrc` - Zsh shell configuration
+- `.zshrc` / `.zshenv` - Zsh shell configuration
+- `.config/zsh/` - Aliases, custom functions, tasks, host-specific settings
 - `.vimrc` - Vim editor configuration
+- `.config/nvim/init.lua` - Neovim configuration
 - `.mise.toml` - mise runtime configuration
-- `.config/zsh/alias.sh` - Custom shell aliases
-- `.config/zsh/command.sh` - Custom shell commands
+- `.gitconfig` / `.gitconfig-olta` - Git configuration (personal / work)
 - `.config/ghostty/config` - Ghostty terminal configuration
 - `.config/tmux/tmux.conf` - Tmux configuration with vim key bindings
-- `.config/karabiner/` - Karabiner-Elements key mapping
-- `.config/helix/config.toml` - Helix editor configuration
+- `.config/karabiner/` - Karabiner-Elements key mapping, built from TypeScript (`karabiner.ts`)
+- `.config/helix/` - Helix editor configuration
 - `.config/yazi/` - Yazi file manager configuration (with projects plugin)
 - `.config/fd/config` - fd default options
-- `.config/cursor/settings.json` - Cursor editor settings
-- `.claude/` - Claude Code configuration and custom commands
+- `.config/sheldon/plugins.toml` - Zsh plugin definitions
+- `.config/starship/starship.toml` - Prompt configuration
+- `.config/cursor/` - Cursor editor settings and keybindings
+- `.config/zed/settings.json` - Zed editor settings
+- `.config/claude/` - Claude Code configuration (`~/.claude` settings and custom commands)
+
+### Docs
+The `docs/` directory keeps decision records and troubleshooting notes (e.g. terminal workflow cheatsheet, cmux vs tmux, Karabiner vs Nix, secure input hotkey outage postmortem).
 
 ## Scripts
 
 ### `install.sh`
-Installs Homebrew, all brew packages from Brewfile, runtimes via mise, Claude Code, and yazi plugins.
+Installs Homebrew → Brewfile packages → mise runtimes → Claude Code → vim-plug → TPM (Tmux Plugin Manager) → yazi plugins → Karabiner config build (via bun).
 
 ### `link.sh`
-Creates symbolic links for configuration files from this repository to their expected locations in your home directory. Existing files are backed up with a `.bak` extension.
+Creates symbolic links for configuration files from this repository to their expected locations. Existing files are backed up with a `.bak` extension. Run `./link.sh --list` to print all entries as `source:destination`.
 
 ### `settings.sh`
-Configures macOS system settings for optimal development experience. Currently includes:
-- Disables press-and-hold for keys in favor of key repeat (allows holding keys to repeat instead of showing accent menu)
-- Requires system restart for changes to take effect
+Configures macOS system settings (requires restart):
+- Disables press-and-hold in favor of key repeat
+- Trackpad: maximum tracking speed, tap to click
+- Frees up Ctrl+Space for the tmux prefix (disables input source switching)
+- Japanese IME (Kotoeri): disables predictive candidates and live conversion
+
+## Karabiner Configuration
+
+`karabiner.json` is generated from `karabiner.ts` using [karabiner.ts](https://github.com/evan-liu/karabiner.ts):
+
+```bash
+cd .config/karabiner
+bun run build   # generate karabiner.json, sync back to repo, reload profile
+```
 
 ## Requirements
 
@@ -83,8 +108,6 @@ Configures macOS system settings for optimal development experience. Currently i
 - Internet connection for downloading dependencies
 
 ## Post-Installation
-
-After running the installation scripts, you may need to:
 
 1. **Restart your shell** or run `source ~/.zshrc` to apply changes
 2. **Trust mise configuration** if you haven't already:
@@ -99,27 +122,22 @@ After running the installation scripts, you may need to:
 
 ## Claude Code Integration
 
-This repository includes Claude Code configuration:
-- `.claude/settings.json` - Permission settings for Claude Code
-- `.claude/commands/` - Custom slash commands for common workflows
+- `.config/claude/settings.json` - Claude Code settings (symlinked to `~/.claude/settings.json`)
+- `.config/claude/commands/` - Custom slash commands (symlinked to `~/.claude/commands`)
 - `CLAUDE.md` - Repository-specific instructions for Claude Code
+
+Note: `.claude/` at the repository root is reserved for this repository's own Claude Code project settings.
 
 ## GitHub Actions
 
-- **test-scripts.yml** - Runs automated tests for installation and configuration scripts
+- **test-scripts.yml** - Runs automated tests for installation and configuration scripts (including Karabiner build verification)
 - **claude.yml** - Claude Code GitHub integration workflow
 - **claude-code-review.yml** - Automated code review with Claude
 
-## Custom Commands
-
-The `.config/zsh/command.sh` includes powerful custom functions:
-- `fzf-select-history*()` - Enhanced command history search
-
 ## Customization
 
-Feel free to modify the configuration files to suit your preferences:
 - Edit `Brewfile` to add/remove brew packages
 - Edit `.mise.toml` to change runtime versions
 - Customize shell aliases in `.config/zsh/alias.sh`
 - Modify zsh configuration in `.zshrc`
-- Add custom Claude Code commands in `.claude/commands/`
+- Add custom Claude Code commands in `.config/claude/commands/`


### PR DESCRIPTION
## Background / 背景

README.md と CLAUDE.md の記述が現在のリポジトリ実態から乖離していた。特に Claude Code 設定のパスが旧構成（`.claude/`）のままで、Karabiner の TypeScript ビルドや近況の追加ツール（neovim, zed, crit, k8s 系）が未記載だった。

## Changes / 変更内容

- ツール一覧を現行 Brewfile に同期（neovim / zed / crit / yq / stern / typescript・yaml-language-server を追加）
- mise 管理ランタイムを `.mise.toml` の実態に更新（bun / terraform / biome / rust + rust-analyzer）
- Claude Code パスを修正: `~/.claude` の管理対象は `.config/claude/`、repo 直下の `.claude/` は予約パスである旨を明記
- Karabiner の TypeScript ビルドワークフローを新設（karabiner.json は直接編集せず `karabiner.ts` → `bun run build`、sync + reload の挙動も記載）
- `install.sh` のチェーンに TPM / Karabiner ビルドを追加、`settings.sh` の説明を現行4項目に更新
- Testing に `test-karabiner-build.sh` を追加、`docs/` ディレクトリ（意思決定記録・トラブルシューティング）の紹介を追加
- 設定ファイル一覧を `link.sh --list` の全エントリと同期

## Impact scope / 影響範囲

ドキュメントのみ（README.md / CLAUDE.md）。スクリプトや設定ファイルの動作変更はなし。

## Testing / 動作確認

- [x] Brewfile / .mise.toml / link.sh --list / install.sh / settings.sh と記述内容を突き合わせて確認
- [x] test-karabiner-build.sh の実装（ドリフト検証）と tmux.conf の Prefix+M バインドを実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)