### PR TITLE
feat(starship): display pi cluster context in dimmed green

### DIFF
--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -26,3 +26,7 @@ style = "green"
 [[kubernetes.contexts]]
 context_pattern = "kind-.*"
 style = "dimmed green"
+
+[[kubernetes.contexts]]
+context_pattern = "pi"
+style = "dimmed green"


### PR DESCRIPTION
## Background / 背景

自宅の Raspberry Pi 上に新しい k8s クラスタ（context 名: `pi`）を構築した。starship のプロンプトではローカル検証用の kind クラスタを `dimmed green` で表示しており、pi クラスタも同じ扱い（ローカル・非本番）で表示したい。

## Changes / 変更内容

- `.config/starship/starship.toml` の `[[kubernetes.contexts]]` に `context_pattern = "pi"` を追加し、kind と同じ `dimmed green` スタイルを設定

## Impact scope / 影響範囲

- starship プロンプトの kubernetes コンテキスト表示のみ。context 名は `pi` の完全一致で、既存の `dev.*` 等のパターンとは衝突しない

## Testing / 動作確認

- [x] `kubectl config get-contexts` で context 名が `pi` であることを確認 / Verified the context name is exactly `pi`
- [x] `./.github/scripts/test-config.sh` で設定ファイルの構文チェックが通ることを確認 / Config syntax test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)