### PR TITLE
ci(claude): allow renovate bot to trigger claude code review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,6 +38,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           model: "claude-sonnet-4-6"
 
+          # Allow bot-created PRs (e.g. Renovate) to trigger the review
+          allowed_bots: "renovate"
+
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide feedback on:


### PR DESCRIPTION
## Background / 背景

Renovate が作成する PR では claude-review ジョブが `Workflow initiated by non-human actor: renovate (type: Bot)` エラーで毎回失敗していた（例: #140, #141）。claude-code-action はデフォルトで bot 起動のワークフローを拒否するため、`allowed_bots` に renovate を追加する必要がある。

## Changes / 変更内容

- `.github/workflows/claude-code-review.yml` の claude-code-action に `allowed_bots: "renovate"` を追加

## Impact scope / 影響範囲

- claude-review ジョブのみ。renovate 起動の PR でレビューが実行されるようになる。`claude.yml`（@claude メンション起動）は renovate がメンションしないため対象外

## Testing / 動作確認

- [x] claude-code-action のソースで `allowed_bots` の照合ロジックを確認（`[bot]` サフィックスは両側で除去されるため `renovate` 指定で一致する）/ Verified matching logic in action source
- [x] 失敗した run のログでエラー文言が `allowed_bots` 未設定起因であることを確認 / Confirmed the failing run's error is caused by missing allowed_bots

🤖 Generated with [Claude Code](https://claude.com/claude-code)