### PR TITLE
ci: run real install.sh and split fast checks from install test

### DIFF
--- a/.github/scripts/test-install.sh
+++ b/.github/scripts/test-install.sh
@@ -26,9 +26,11 @@ fi
 #   MISE_DISABLE_TOOLS         - skip heavy runtimes (gcloud, terraform, rust)
 #   MISE_TRUSTED_CONFIG_PATHS  - trust the repo .mise.toml non-interactively
 
-# On a real machine Karabiner-Elements (cask) creates this directory;
-# the cask is skipped in CI so create it for the Karabiner build step.
+# On a real machine Karabiner-Elements creates ~/.config/karabiner/karabiner.json
+# on first launch, and karabiner.ts writeToProfile requires it to exist. The cask
+# is skipped in CI, so seed it with the repo copy for the Karabiner build step.
 mkdir -p ~/.config/karabiner
+cp .config/karabiner/karabiner.json ~/.config/karabiner/karabiner.json
 
 echo "Executing install.sh..."
 ./install.sh

--- a/.github/scripts/test-install.sh
+++ b/.github/scripts/test-install.sh
@@ -20,138 +20,72 @@ else
   exit 1
 fi
 
-# Check if Homebrew is already available in CI
-if command -v brew &> /dev/null; then
-  echo "✓ Homebrew is already available in CI environment"
-  brew --version
-else
-  echo "ℹ️  Homebrew not pre-installed, would be installed by script"
-fi
+# CI tailoring is injected via environment variables set in the workflow,
+# so the real install.sh runs unmodified:
+#   HOMEBREW_BUNDLE_CASK_SKIP  - skip GUI casks (large downloads, nothing to verify in CI)
+#   MISE_DISABLE_TOOLS         - skip heavy runtimes (gcloud, terraform, rust)
+#   MISE_TRUSTED_CONFIG_PATHS  - trust the repo .mise.toml non-interactively
 
-# Create a CI-safe version of install.sh for testing
-echo "Creating CI-safe test version..."
-cat > install-test.sh << 'SCRIPT_EOF'
-#!/bin/sh
+# On a real machine Karabiner-Elements (cask) creates this directory;
+# the cask is skipped in CI so create it for the Karabiner build step.
+mkdir -p ~/.config/karabiner
 
-# Get the script directory to ensure correct paths
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+echo "Executing install.sh..."
+./install.sh
 
-# Check if Homebrew is already installed
-if command -v brew &> /dev/null; then
-  echo "✓ Homebrew already available, skipping installation"
-  eval "$(/opt/homebrew/bin/brew shellenv)" 2>/dev/null || true
-else
-  echo "Installing Homebrew..."
-  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-  (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> $HOME/.zprofile
-  
-  # Source brew environment if it exists
-  if [ -f "/opt/homebrew/bin/brew" ]; then
-      eval "$(/opt/homebrew/bin/brew shellenv)"
-  fi
-fi
-
-# install via brew using absolute path to Brewfile
-echo "Installing packages from Brewfile..."
-brew bundle install --file="$SCRIPT_DIR/Brewfile"
-
-# Install nvm (Node Version Manager)
-echo "Installing nvm..."
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-
-# Load nvm for current session
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-
-# Install latest LTS version of Node.js
-echo "Installing latest LTS version of Node.js..."
-nvm install --lts
-nvm use --lts
-
-# Install global npm packages
-echo "Installing Claude Code and Gemini CLI..."
-npm install -g @anthropic-ai/claude-code
-npm install -g @google/gemini-cli       
-
-# Skip Google Cloud CLI installation in CI (it's large and not essential for testing)
-echo "Skipping Google Cloud CLI installation in CI environment"
-echo "✓ install.sh test execution completed"
-SCRIPT_EOF
-
-chmod +x install-test.sh
-
-echo "Test script content:"
-cat install-test.sh
-
-echo "Executing test installation..."
-./install-test.sh
-
-# Verify that key tools are available after installation
+# Verify brew formulas from the Brewfile
 echo "Verifying installed CLI tools..."
 exit_code=0
-for tool in fzf gh zoxide lsd bat starship; do
+for tool in fzf gh zoxide lsd bat starship sheldon tmux mise; do
   if command -v "$tool" &> /dev/null; then
     echo "✓ CLI tool successfully installed: $tool"
-    "$tool" --version 2>/dev/null || echo "  (version check failed, but command exists)"
   else
     echo "✗ CLI tool not available: $tool"
     exit_code=1
   fi
 done
 
-# Verify Node.js and npm installation
-echo "Verifying Node.js and npm installation..."
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+# Verify mise-managed runtimes (gcloud/terraform/rust are disabled in CI)
+echo "Verifying mise-managed runtimes..."
+for tool in node bun; do
+  if mise which "$tool" &> /dev/null; then
+    echo "✓ mise runtime installed: $tool ($(mise which "$tool"))"
+  else
+    echo "✗ mise runtime not available: $tool"
+    exit_code=1
+  fi
+done
 
-if command -v node &> /dev/null; then
-  echo "✓ Node.js successfully installed: $(node --version)"
-else
-  echo "✗ Node.js not available"
-  exit_code=1
-fi
-
-if command -v npm &> /dev/null; then
-  echo "✓ npm successfully installed: $(npm --version)"
-else
-  echo "✗ npm not available"
-  exit_code=1
-fi
-
-# Verify npm global packages
-echo "Verifying npm global packages..."
-if command -v claude &> /dev/null; then
-  echo "✓ Claude Code successfully installed: $(claude --version 2>/dev/null || echo 'command exists')"
+# Verify Claude Code (native installer puts the binary in ~/.local/bin)
+if [ -x "$HOME/.local/bin/claude" ] || command -v claude &> /dev/null; then
+  echo "✓ Claude Code successfully installed"
 else
   echo "✗ Claude Code not available"
   exit_code=1
 fi
 
-if command -v gemini &> /dev/null; then
-  echo "✓ Gemini CLI successfully installed: $(gemini --version 2>/dev/null || echo 'command exists')"
+# Verify vim-plug and TPM
+if [ -f "$HOME/.vim/autoload/plug.vim" ]; then
+  echo "✓ vim-plug installed"
 else
-  echo "✗ Gemini CLI not available"
+  echo "✗ vim-plug not installed"
   exit_code=1
 fi
-        
-# Verify cask applications (these won't be in PATH but should be installed)
-echo "Checking cask applications..."
-if brew list --cask | grep -q ghostty; then
-  echo "✓ Cask application installed: ghostty"
+
+if [ -d "$HOME/.tmux/plugins/tpm" ]; then
+  echo "✓ TPM installed"
 else
-  echo "ℹ️  Cask application not installed or not available in CI: ghostty"
+  echo "✗ TPM not installed"
+  exit_code=1
 fi
 
-# Test that brew bundle check now passes
+# Test that brew bundle check now passes (informational: casks are skipped in CI)
 echo "Testing brew bundle check after installation..."
 if brew bundle check --file=./Brewfile; then
   echo "✓ All Brewfile dependencies are now satisfied"
 else
-  echo "ℹ️  Some dependencies still missing (may be expected)"
+  echo "ℹ️  Some dependencies still missing (expected in CI: casks are skipped)"
 fi
-
-# Cleanup
-rm -f install-test.sh
 
 if [ $exit_code -eq 0 ]; then
   echo "✓ install.sh actual execution test completed successfully"

--- a/.github/scripts/test-install.sh
+++ b/.github/scripts/test-install.sh
@@ -21,7 +21,9 @@ else
 fi
 
 # CI tailoring is injected via environment variables set in the workflow,
-# so the real install.sh runs unmodified:
+# so the real install.sh runs unmodified. These are native interfaces of
+# brew bundle (man brew) and mise (settings overridable as MISE_* env vars),
+# not something implemented in this repo:
 #   HOMEBREW_BUNDLE_CASK_SKIP  - skip GUI casks (large downloads, nothing to verify in CI)
 #   MISE_DISABLE_TOOLS         - skip heavy runtimes (gcloud, terraform, rust)
 #   MISE_TRUSTED_CONFIG_PATHS  - trust the repo .mise.toml non-interactively

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -103,6 +103,9 @@ jobs:
       # Heavy runtimes add minutes without exercising extra install.sh logic
       MISE_DISABLE_TOOLS: "gcloud,terraform,rust,rust-analyzer"
       MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
+      # mise hits the GitHub Releases API (aqua backend); unauthenticated
+      # requests share a 60/hr per-IP limit across hosted runners and flake
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".config/**"
       - ".github/**"
+      - ".mise.toml"
       - ".vimrc"
       - ".zshrc"
       - "Brewfile"
@@ -17,6 +18,7 @@ on:
     paths:
       - ".config/**"
       - ".github/**"
+      - ".mise.toml"
       - ".vimrc"
       - ".zshrc"
       - "Brewfile"
@@ -24,23 +26,51 @@ on:
       - "link.sh"
       - "settings.sh"
 
+# Cancel superseded runs on the same PR; never cancel main pushes
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  test-macos:
-    runs-on: macos-latest
-    
+  # Detect whether install-related files changed, so the slow
+  # install test only runs when it can actually catch something
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      install: ${{ steps.filter.outputs.install }}
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
-      
+
+    - name: Detect changed paths
+      id: filter
+      uses: dorny/paths-filter@v3
+      with:
+        filters: |
+          install:
+            - 'install.sh'
+            - 'Brewfile'
+            - '.mise.toml'
+            - '.github/workflows/test-scripts.yml'
+            - '.github/scripts/test-install.sh'
+
+  # Fast checks (~30s): symlinks, config syntax, karabiner build, settings
+  test-macos:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+
     - name: Set up environment
       run: ./.github/scripts/setup-environment.sh
-    
-    - name: Test install.sh (actual execution)
-      run: ./.github/scripts/test-install.sh
-    
+
     - name: Test link.sh
       run: ./.github/scripts/test-link.sh
-    
+
     - name: Test configuration files
       run: ./.github/scripts/test-config.sh
 
@@ -52,10 +82,31 @@ jobs:
 
     - name: Test Brewfile
       run: ./.github/scripts/test-brewfile.sh
-    
+
     - name: Test settings.sh
       run: ./.github/scripts/test-settings.sh
-    
+
     - name: Cleanup
       if: always()
       run: ./.github/scripts/cleanup-environment.sh
+
+  # Full install test: runs the real install.sh, tailored for CI via env vars only
+  test-install:
+    needs: changes
+    if: needs.changes.outputs.install == 'true'
+    runs-on: macos-latest
+    env:
+      # GUI casks are large downloads and nothing in CI verifies them
+      HOMEBREW_BUNDLE_CASK_SKIP: "ghostty cursor zed font-hack-nerd-font"
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+      # Heavy runtimes add minutes without exercising extra install.sh logic
+      MISE_DISABLE_TOOLS: "gcloud,terraform,rust,rust-analyzer"
+      MISE_TRUSTED_CONFIG_PATHS: ${{ github.workspace }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+
+    - name: Test install.sh (actual execution)
+      run: ./.github/scripts/test-install.sh


### PR DESCRIPTION
## Background / 背景

test-macos は毎回約2分7秒かかっており、その9割が `Test install.sh`（166秒）だった。さらに調査の結果、test-install.sh は実物の install.sh ではなく heredoc で埋め込まれた「CI-safe版」を実行しており、実物から完全にドリフトしていた（nvm + npm global で claude-code / gemini-cli をインストールするが、実物は mise + native installer。gemini は実物に存在しない）。実物の mise 経路は一切テストされていなかった。

## Changes / 変更内容

**test-install.sh: 実物の install.sh を実行するよう書き換え**
- heredoc のコピーを廃止し、`./install.sh` をそのまま実行。CI 特有の調整は環境変数のみで注入（install.sh 本体は無改修）
  - `HOMEBREW_BUNDLE_CASK_SKIP`: GUI cask 4つをスキップ（約50秒削減、CI では informational チェックしかしていなかった）
  - `MISE_DISABLE_TOOLS=gcloud,terraform,rust,rust-analyzer`: 重いランタイムを除外しつつ node / bun / biome で mise 経路を検証
  - `MISE_TRUSTED_CONFIG_PATHS`: 非対話環境での config trust
- 検証項目を実物に合わせて更新（mise 由来の node/bun、native installer の claude、vim-plug、TPM）

**workflow: ジョブ分割と無駄 run の削減**
- `test-macos`（fast、毎回実行）: link / config / karabiner build / brewfile / settings — 約30秒
- `test-install`: `dorny/paths-filter` で install.sh / Brewfile / .mise.toml / 関連 CI ファイルの変更時のみ実行
- `concurrency` + `cancel-in-progress` で同一 PR への連続 push 時に古い run を自動キャンセル（main への push はキャンセルしない）
- workflow の paths トリガーに `.mise.toml` を追加

## Impact scope / 影響範囲

- CI のみ。install.sh / link.sh / Brewfile 等の実体は無変更
- ruleset に必須ステータスチェックの指定がないことを確認済み（ジョブ追加・分割によるマージブロックなし）
- 期待効果: 設定変更のみの PR は約30秒、install 関連の変更時も cask スキップにより約60〜90秒（従来は一律約2分強）

## Testing / 動作確認

- [x] `bash -n` と yq で構文検証 / Syntax validated with bash -n and yq
- [x] `MISE_DISABLE_TOOLS` で node / bun / biome のみに絞られることを実機確認 / Verified tool filtering locally
- [x] `ya pkg install` が設定なしの HOME でも exit 0 になることを実機確認（CI で実物 install.sh が通る前提の検証）/ Verified ya pkg install succeeds with empty HOME
- [x] `HOMEBREW_BUNDLE_CASK_SKIP` が brew bundle の公式環境変数であることを man で確認 / Confirmed in man brew
- [x] この PR 自体で test-install ジョブが実走し、全検証項目が pass（1m21s） / This PR itself triggers the test-install job as a live validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
