### PR TITLE
feat(ghostty): map shift+enter to esc+cr for newline in claude code

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -23,3 +23,7 @@ background-opacity-cells = true
 
 # Cmd+Shift+T で透過⇄不透明をトグル（macOS のみ実装）
 keybind = cmd+shift+t=toggle_background_opacity
+
+# Shift+Enter を ESC+CR (Meta+Enter) として送る。Claude Code が改行と解釈する。
+# バイト列なので tmux を素通し、tmux 内の Claude Code でも改行できる
+keybind = shift+enter=text:\x1b\r


### PR DESCRIPTION
## Background / 背景

tmux + ghostty 環境では Claude Code 内の改行に `\` を使う必要があり、Shift+Enter が使えなかった（Claude Code の `/terminal-setup` 相当の仕組みが tmux 内では効かない）。

## Changes / 変更内容

ghostty の keybind で Shift+Enter を `\x1b\r`（ESC+CR = Meta+Enter）のバイト列として送信するよう追加。Claude Code はこのシーケンスを改行として解釈する。

## Impact scope / 影響範囲

- ghostty 全体で Shift+Enter が ESC+CR になる（Claude Code 以外のアプリにも適用）
- ほとんどのシェル・TUI では未定義シーケンスとして無視されるか Enter 扱いで実害なし
- バイト列なので tmux・SSH を素通しし、ネストした環境でも動作する

## Testing / 動作確認

- [ ] 設定リロード（Cmd+Shift+,）後、tmux 内の Claude Code で Shift+Enter で改行できること / Newline works with Shift+Enter in Claude Code inside tmux after config reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)