### PR TITLE
fix(tmux): adapt yazi-picker to nvim and move under tmux config

### DIFF
--- a/.config/tmux/tmux.conf
+++ b/.config/tmux/tmux.conf
@@ -58,9 +58,9 @@ bind Space last-window
 bind c new-window -c '#{pane_current_path}'
 
 # yazi を popup で開く (popup は passthrough 非対応のため新セッション経由)
-# 選択したファイルパスを元のペイン (Helix 等) に :open で送る
+# 選択したファイルパスを元のペイン (Neovim 等) に送る
 # https://github.com/sxyazi/yazi/issues/2308#issuecomment-2731102243
-bind y run-shell -b 'tmux display-popup -d "#{pane_current_path}" -w 80% -h 80% -E "bash ~/.config/helix/yazi-picker.sh #{pane_id}"'
+bind y run-shell -b 'tmux display-popup -d "#{pane_current_path}" -w 90% -h 90% -E "bash ~/.config/tmux/yazi-picker.sh #{pane_id}"'
 
 # HRM (Home Row Mods) チートシートを popup で開く
 # 既定の `m` (select-pane -m / mark-pane) は使わないので上書き

--- a/.config/tmux/yazi-picker.sh
+++ b/.config/tmux/yazi-picker.sh
@@ -6,15 +6,16 @@ tmp=$(mktemp /tmp/yazi-chosen.XXXXXX)
 tmux new-session "yazi --chooser-file=$tmp" \; set status off
 
 if [[ -s "$tmp" ]]; then
-	paths=$(cat "$tmp")
+	# chooser-file は改行区切り。send-keys に改行を渡すと途中で実行されるため空白区切りに変換
+	paths=$(tr '\n' ' ' < "$tmp")
 	current_cmd=$(tmux display-message -t "$CALLER_PANE" -p '#{pane_current_command}')
 
-	if [[ "$current_cmd" == "hx" ]]; then
+	if [[ "$current_cmd" == "nvim" ]]; then
 		tmux send-keys -t "$CALLER_PANE" Escape
-		tmux send-keys -t "$CALLER_PANE" ":open $paths"
+		tmux send-keys -t "$CALLER_PANE" ":args $paths"
 		tmux send-keys -t "$CALLER_PANE" Enter
 	else
-		tmux send-keys -t "$CALLER_PANE" "hx \"$paths\""
+		tmux send-keys -t "$CALLER_PANE" "nvim $paths"
 		tmux send-keys -t "$CALLER_PANE" Enter
 	fi
 fi

--- a/link.sh
+++ b/link.sh
@@ -12,11 +12,11 @@ entries=(
   .config/helix/config.toml
   .config/helix/languages.toml
   .config/helix/themes/bogster-custom.toml
-  .config/helix/yazi-picker.sh
   .config/karabiner/HRM.md
   .config/karabiner/karabiner.json
   .config/nvim/init.lua
   .config/sheldon/plugins.toml
+  .config/tmux/yazi-picker.sh
   .config/yazi/init.lua
   .config/yazi/keymap.toml
   .config/yazi/package.toml


### PR DESCRIPTION
## Background / 背景

#147 でデフォルトエディタを helix から nvim に切り替えたが、tmux の `Prefix+y`（yazi popup）から呼ばれる `yazi-picker.sh` は helix 前提のままで、ファイルを選択すると `hx` が起動していた。また、スクリプトの置き場所が `.config/helix/` のままなのも helix 時代の名残だった。

## Changes / 変更内容

- `yazi-picker.sh` を nvim 対応に修正（nvim ペイン内では `:args`、シェルでは `nvim` を send-keys）
- 複数ファイル選択時のバグを修正（chooser-file の改行区切り出力がそのまま send-keys され途中で実行されていたため、空白区切りに変換）
- スクリプトを `.config/helix/` → `.config/tmux/` へ移動。参照しているのは `tmux.conf` の bind のみで、ロジックも tmux の配管（popup / send-keys）が本体のため
- `link.sh` のエントリと `tmux.conf` の呼び出しパスを更新
- yazi popup のサイズを 80% → 90% に拡大

## Impact scope / 影響範囲

- tmux の `Prefix+y` バインドのみ。yazi 本体の設定・helix の設定には影響なし
- symlink 構成の変更: `~/.config/helix/yazi-picker.sh` を削除し `~/.config/tmux/yazi-picker.sh` を作成（実施済み）

## Testing / 動作確認

- [x] `bash -n` による構文チェック / Syntax check passed
- [x] `tmux source-file` 後、`tmux list-keys` で bind が新パス・90% サイズを指すことを確認
- [x] `./.github/scripts/test-link.sh` 成功
- [x] symlink `~/.config/tmux/yazi-picker.sh` → repo が有効なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)