### PR TITLE
fix(zsh): keep emacs keybindings after switching EDITOR to nvim

### DIFF
--- a/.config/zsh/command.sh
+++ b/.config/zsh/command.sh
@@ -1,3 +1,7 @@
+# EDITOR=nvim だと zsh が vi モードを推測するため、emacs キーバインドを明示する。
+# 個別の bindkey を上書きしないよう、必ずファイル先頭に置くこと。
+bindkey -e
+
 # copy a line Ctrl + CP
 history-current-pbcopy() {
   print "$BUFFER" | tr -d "\r\n" | pbcopy


### PR DESCRIPTION
## Background / 背景

#147 で `EDITOR` を `hx` → `nvim` に変更した結果、zsh がキーマップを vi モードと推測するようになり（`$EDITOR` に `vi` が含まれるため）、`Ctrl+A` / `Ctrl+E` での行頭・行末移動が効かず `^A` がそのまま入力される状態になっていた。

## Changes / 変更内容

- `.config/zsh/command.sh` の先頭に `bindkey -e` を追加し、emacs キーバインドを明示
- 既存の個別 `bindkey`（`^P^O`, `^G`）を上書きしないよう、必ず先頭に置く旨のコメントを追加

## Impact scope / 影響範囲

- 新しく起動する zsh すべてで emacs キーバインドに固定される（既存シェルは `exec zsh` で反映）
- 既存の個別 bindkey には影響なし

## Testing / 動作確認

- [x] `zsh -n` で構文チェック / Syntax check passed
- [x] `EDITOR=nvim zsh -i` で main キーマップが emacs になり、`^A`→beginning-of-line / `^E`→end-of-line を確認 / Verified emacs keymap and Ctrl+A/E bindings in a fresh shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)