### PR TITLE
chore(starship): disable aws/terraform modules and drop gcloud icon

### DIFF
--- a/.config/starship/starship.toml
+++ b/.config/starship/starship.toml
@@ -3,8 +3,14 @@
 # プロンプトの表示順序を制御
 format = """$directory$git_branch$git_status$kubernetes$gcloud$all"""
 
+[aws]
+disabled = true
+
 [gcloud]
-format = '[$symbol$active]($style) '
+format = '[$active]($style) '
+
+[terraform]
+disabled = true
 
 [kubernetes]
 format = '[$context]($style) '


### PR DESCRIPTION
## Background / 背景

プロンプトに表示される `on ☁️ (ap-northeast-1)` の正体を調査したところ、starship の aws モジュールが `~/.aws/config` の `[default]` セクションからリージョンだけを拾って表示していた（プロファイル名は `AWS_PROFILE` 未設定のため非表示）。また `via 💠 default` は terraform モジュールの workspace 表示だが、workspace 機能を使っておらず常に暗黙の `default` が表示されるだけで情報価値がなかった。

## Changes / 変更内容

- `[aws]` モジュールを無効化（リージョン表示を削除）
- `[terraform]` モジュールを無効化（workspace 表示を削除）
- `[gcloud]` のフォーマットから `$symbol`（☁️）を削除し、プロジェクト名のみ表示

## Impact scope / 影響範囲

starship プロンプトの表示のみ。kubernetes context の表示・色分け、gcloud プロジェクト名の表示は従来どおり維持。

## Testing / 動作確認

- [x] `~/.config/starship.toml` が repo への symlink であることを確認（変更が即反映される）
- [x] 新しいプロンプトで aws リージョン・terraform workspace・gcloud アイコンが非表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)