### PR TITLE
fix(karabiner): move tmux IME bypass from ctrl+b to ctrl+space

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -7,7 +7,7 @@ font-size = 13
 macos-option-as-alt = true
 macos-titlebar-style = hidden
 
-# 分割は tmux (Ctrl+b, % / ") で行うため無効化。右 Cmd 単押し→D の誤爆対策も兼ねる
+# 分割は tmux (Ctrl+Space, % / ") で行うため無効化。右 Cmd 単押し→D の誤爆対策も兼ねる
 keybind = cmd+d=unbind
 keybind = cmd+shift+d=unbind
 

--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -30,7 +30,7 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 | Ctrl + , / .              | Option + ← / →  (word jump)                  |
 | Ctrl + w                  | Page Up                                      |
 | Ctrl + v                  | Page Down                                    |
-| Ctrl + b  (terminal)      | 英数 → Ctrl+b  (tmux prefix の前に IME 抜け) |
+| Ctrl + Space  (terminal)  | 英数 → Ctrl+Space  (tmux prefix と同時に IME 抜け) |
 | Ctrl + g  (zsh)           | clear-screen  (Ctrl+L が → に潰れる代替)     |
 | Ctrl + P, Ctrl + O  (zsh) | 現在行を pbcopy                              |
 

--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -48,7 +48,7 @@
               {
                 "type": "basic",
                 "from": {
-                  "key_code": "b",
+                  "key_code": "spacebar",
                   "modifiers": {
                     "mandatory": [
                       "left_control"
@@ -63,7 +63,7 @@
                     "key_code": "japanese_eisuu"
                   },
                   {
-                    "key_code": "b",
+                    "key_code": "spacebar",
                     "modifiers": [
                       "left_control"
                     ]

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -83,11 +83,11 @@ writeToProfile('Default profile', [
       .parameters({ 'basic.to_if_alone_timeout_milliseconds': 300 }),
 
     map({
-      key_code: 'b',
+      key_code: 'spacebar',
       modifiers: { mandatory: ['left_control'], optional: ['any'] },
     })
       .to({ key_code: 'japanese_eisuu' })
-      .to({ key_code: 'b', modifiers: ['left_control'] }),
+      .to({ key_code: 'spacebar', modifiers: ['left_control'] }),
   ]),
 
   rule('Ctrl navigation (hjkl / word / page)').manipulators([

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ cd .config/karabiner && bun run build  # generate → sync repo copy → reload 
 `build` regenerates the config, copies `~/.config/karabiner/karabiner.json` back into the repo (Karabiner's atomic writes break symlinks), and reloads the profile via `karabiner_cli`.
 
 ### Docs
-`docs/` holds decision records and troubleshooting notes (terminal-workflow cheatsheet, cmux-vs-tmux, karabiner-vs-nix, brew-vs-nix, raycast-dotfiles, secure-input-hotkey-outage). The terminal-workflow cheatsheet is symlinked for the tmux Prefix+M popup.
+`docs/` holds decision records and troubleshooting notes (terminal-workflow cheatsheet, cmux-vs-tmux, karabiner-vs-nix, brew-vs-nix, raycast-dotfiles, secure-input-hotkey-outage) and the tooling-roadmap (planned improvements with adopt/reject status). The terminal-workflow cheatsheet is symlinked for the tmux Prefix+M popup.
 
 ### Workspace Conventions
 Custom shell functions assume this structure:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ mise install
 - `.config/claude/` - Claude Code configuration (`~/.claude` settings and custom commands)
 
 ### Docs
-The `docs/` directory keeps decision records and troubleshooting notes (e.g. terminal workflow cheatsheet, cmux vs tmux, Karabiner vs Nix, brew vs Nix, secure input hotkey outage postmortem).
+The `docs/` directory keeps decision records and troubleshooting notes (e.g. terminal workflow cheatsheet, cmux vs tmux, Karabiner vs Nix, brew vs Nix, secure input hotkey outage postmortem) and the tooling roadmap.
 
 ## Scripts
 

--- a/docs/terminal-workflow.md
+++ b/docs/terminal-workflow.md
@@ -118,18 +118,8 @@ tmux 内から `Prefix` → `y` でポップアップ起動。Helix で開いて
 
 | キー | 動作 | 備考 |
 |---|---|---|
-| `Ctrl+B` | 英数 → `Ctrl+B` | tmux prefix 送出前に IME を抜く（prefix 自体は `Ctrl+Space`） |
+| `Ctrl+Space` | 英数 → `Ctrl+Space` | tmux prefix の送出と同時に IME を抜く |
 | `Ctrl` 単押し | 短時間ホールド | 端末向け tap-hold 判定 |
-
-## Helix Editor / エディタ
-
-| ユースケース | キー | 備考 |
-|---|---|---|
-| 行を上に移動 | `Alt+Up` | |
-| 行を下に移動 | `Alt+Down` | |
-| Inlay hints 切替 | `Space` → `I` | |
-| ファイルピッカー | `Space` → `f` | 隠しファイルも表示 |
-| バッファピッカー | `Space` → `b` | 開いているファイル一覧 |
 
 ## Typical Workflows / よくある作業フロー
 

--- a/docs/tooling-roadmap.md
+++ b/docs/tooling-roadmap.md
@@ -1,0 +1,76 @@
+# dotfiles 改善ロードマップ (2026-07)
+
+Nix 導入の見送り（→ [brew-vs-nix.md](brew-vs-nix.md)）を受けて、「Nix に期待していた性質を、Nix なしの個別ツールで回収できないか」という観点で改善候補を調査した結果と、その採否。
+
+## 方針
+
+Nix に期待していた性質を分解すると、それぞれ独立に回収できる:
+
+| Nix に期待していた性質 | Nix なしでの回収手段 |
+|---|---|
+| パッケージバージョンの追跡・再現 | `Brewfile.lock.json` + 定期チェック（→ 3） |
+| セットアップ手順の宣言化 | mise tasks（→ 4） |
+| 構成の正しさの担保 | CI の近代化（→ 2） |
+| 設定をプログラミング言語で書ける | `karabiner.ts` パターンの水平展開 → **調査の結果、保留に降格**（→ 1） |
+
+## やる ✅
+
+### 2. CI の近代化 — bats-core + shellcheck / shfmt + actionlint
+
+現在の `.github/scripts/test-*.sh` は自作のアドホックなテスト。以下に置き換え・追加する:
+
+- [bats-core](https://github.com/bats-core/bats-core) でシェルテストを構造化（setup/teardown、アサーション、個別実行）
+- shellcheck + shfmt を PR に適用（[action-sh-checker](https://github.com/luizm/action-sh-checker) 等）— install.sh / link.sh / zsh functions の静的解析と整形チェック
+- [actionlint](https://github.com/rhysd/actionlint) で workflow 定義自体も検査
+
+### 3. Brewfile のロックファイル運用
+
+`brew bundle install` が生成する `Brewfile.lock.json`（全 formula の正確なバージョン記録）をコミットし、scheduled GitHub Action で定期的な outdated チェック（レポート or 自動 PR）を回す。
+
+- 「何がいつ上がったか」の追跡と、事故時の原因特定が目的
+- brew の auto-update 由来の非再現性への対処として、Nix の世代管理の実用上の大部分をカバーする
+
+### 4. mise tasks への統合
+
+mise 内蔵の[タスクランナー](https://mise.jdx.dev/tasks/)（依存関係・並列実行・last-modified スキップ付き）に、`install.sh` の手続き連鎖（vim-plug → TPM → yazi plugins → karabiner build）や `.config/zsh/tasks.sh` を移す。
+
+- 既に mise を使っているため追加ツール不要。Make / just 相当を 1 ツールで済ませられる
+- 「brew first / mise 格上げ」の既存方針（→ [CLAUDE.md](../CLAUDE.md)）とも整合する
+
+## やらない ❌
+
+### chezmoi への link.sh 移行
+
+chezmoi の主要な強み（マシン間テンプレート・秘密情報の暗号化管理）は、複数マシンを使い回さない本環境の運用実態（→ [brew-vs-nix.md](brew-vs-nix.md) の背景と同じ）では効かない。symlink 27 本は link.sh で問題なく管理できており、移行コストに見合う上積みがない。Nix と同じ構造の結論。
+
+### Codespaces / devcontainer 対応
+
+GitHub は dotfiles リポジトリのネイティブ連携（`install.sh` 自動実行）を持つが、ローカル完結の現運用では実利が薄い。cloud 開発環境を常用するようになったら再検討。
+
+## 保留 🤔
+
+### 1. Config as Code の拡張 — 共通トークンの一元化（2026-07 調査で降格）
+
+フォント名・カラーテーマ等のツール横断の共有値を TypeScript で一元定義し、各 config を生成する構想（`karabiner.ts` パターンの水平展開）だったが、**現状の config を横断調査した結果、共有値がほぼ存在しなかった**:
+
+- フォント: ghostty は SF Mono、zed は family 未指定。重複なし
+- カラーテーマ: tmux / zed / starship で各々独立、パレット共有ゼロ
+- `$EDITOR`: `.zshenv` の 1 箇所定義で既に一元化済み
+
+実在したのは共有値ではなく「ツール間の暗黙の契約」（tmux.conf が知る ghostty の TERM 名、karabiner の terminal bundle ID、tmux prefix と Karabiner IME bypass の対応）で、件数が少なく生成基盤を作る規模ではない。調査で見つかった不整合（prefix C-Space 化に対して IME bypass が旧 C-b のまま等）は手動で修正済み。**複数ツールでテーマ・フォントを統一したくなったタイミングで再検討する。**
+
+### その他
+
+- **nvim の lazy.nvim 化**: `init.lua` は意図的に最小構成のため、プラグイン管理を育てる需要が出てからで良い
+- **README のアーキテクチャ図（mermaid）・docs 索引の整備**: 実害がないため優先度低。上記 1〜4 で構成が変わってから書く方が手戻りがない
+
+## 実施順序の目安
+
+2（CI 近代化）→ 3（lockfile）→ 4（mise tasks）を推奨。
+
+## 参考リンク
+
+- [mise Tasks](https://mise.jdx.dev/tasks/) / [Make vs Just vs Mise vs go-task (2026)](https://mehdihadeli.com/blog/task-runners-comparison-2026) / [Replacing Makefile, direnv, asdf and more with Mise](https://andri.dk/blog/2025/mise-en-place/)
+- [bats-core](https://github.com/bats-core/bats-core) / [action-sh-checker](https://github.com/luizm/action-sh-checker) / [actionlint](https://github.com/rhysd/actionlint) / [ShellCheck GitHub Actions wiki](https://www.shellcheck.net/wiki/GitHub-Actions)
+- [Why use chezmoi?](https://www.chezmoi.io/why-use-chezmoi/) / [Exploring Tools For Managing Your Dotfiles](https://gbergatto.github.io/posts/tools-managing-dotfiles/)
+- [GitHub Codespaces dotfiles 連携](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers)


### PR DESCRIPTION
## Background / 背景

ツール横断の設定依存を調査した際、tmux prefix を `Ctrl+Space` に変更した後も Karabiner の「tmux IME bypass」rule（英数に切り替えてからキーを送出）が旧 prefix の `Ctrl+B` に張られたままであることを発見した。`Ctrl+B` は tmux 側で unbind 済みのため、この rule は本来の目的（かなモードのまま prefix を叩いても次のキーが IME に食われないようにする）を果たせていなかった。

あわせて、同調査で見つかった古い記述の掃除と、dotfiles 改善ロードマップの追加を行う。

## Changes / 変更内容

- `karabiner.ts`: IME bypass を `Ctrl+B` → `Ctrl+Space`（現 prefix）に張り直し、`karabiner.json` を再生成。かなモード中でも prefix 1 打で IME 抜け + prefix 送出が完結する
- `ghostty/config`: 分割キーのコメントを `Ctrl+b` → `Ctrl+Space` に修正
- `HRM.md` / `docs/terminal-workflow.md`: 該当行を現仕様に更新
- `docs/terminal-workflow.md`: 撤去済み Helix のキーバインド表を削除（#151 の取りこぼし）
- `docs/tooling-roadmap.md` を新規追加: 改善候補の調査結果と採否（採用: CI 近代化 / Brewfile lockfile / mise tasks、保留: config 生成 — 横断調査の結果ツール間の共有値がほぼ無かったため）。README / CLAUDE.md の docs 一覧にも追記

## Impact scope / 影響範囲

- Karabiner: ターミナル内で `Ctrl+Space` 押下時に英数への切り替えが先行するようになる（tmux prefix の挙動自体は不変）。`Ctrl+B` への remap は消え、素の `Ctrl+B`（emacs キーバインドの backward-char）に戻る
- そのほかはドキュメント・コメントのみ

## Testing / 動作確認

- [x] `bun run build` で karabiner.json 再生成・プロファイル reload 成功 / Karabiner rebuild & reload OK
- [x] 生成された karabiner.json に spacebar + eisuu の bypass が入っていることを確認 / verified in generated JSON
- [x] `./.github/scripts/test-config.sh` パス（tmux 構文・Karabiner JSON valid）/ passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)