### PR TITLE
fix(ci): drop stale vim-plug check from test-install.sh

### DIFF
--- a/.github/scripts/test-install.sh
+++ b/.github/scripts/test-install.sh
@@ -68,14 +68,7 @@ else
   exit_code=1
 fi
 
-# Verify vim-plug and TPM
-if [ -f "$HOME/.vim/autoload/plug.vim" ]; then
-  echo "✓ vim-plug installed"
-else
-  echo "✗ vim-plug not installed"
-  exit_code=1
-fi
-
+# Verify TPM
 if [ -d "$HOME/.tmux/plugins/tpm" ]; then
   echo "✓ TPM installed"
 else


### PR DESCRIPTION
## Background / 背景

#162 のレビュー対応で vim-plug セットアップタスクを削除した際、`test-install.sh` の検証リストに残っていた「vim-plug がインストールされているか」のチェックを見落とし、test-install job が fail した（[失敗 run](https://github.com/HagaSpa/dotfiles/actions/runs/29722231180)）。

## Changes / 変更内容

- `test-install.sh` から vim-plug の検証ブロックを削除（他の検証項目は現行フローと整合していることを確認済み）

## Impact scope / 影響範囲

- CI の test-install job のみ。マージ後の main push で green に戻る見込み

## Testing / 動作確認

- [x] shellcheck / shfmt / bash -n パス / lint clean
- [x] 検証セクション全体を目視確認し、他に stale なチェックがないことを確認 / no other stale checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)