### PR TITLE
feat(zed): add j/k scroll in markdown preview

### DIFF
--- a/.config/zed/keymap.json
+++ b/.config/zed/keymap.json
@@ -1,0 +1,17 @@
+// Zed keymap
+//
+// For information on binding keys, see the Zed documentation:
+// https://zed.dev/docs/key-bindings
+//
+// To see the default key bindings run `zed: open default keymap`
+// from the command palette.
+[
+  // Markdown プレビュー（cmd-shift-v）で j/k 上下スクロール
+  {
+    "context": "MarkdownPreview",
+    "bindings": {
+      "j": "markdown::ScrollDown",
+      "k": "markdown::ScrollUp"
+    }
+  }
+]

--- a/link.sh
+++ b/link.sh
@@ -18,6 +18,7 @@ entries=(
   .config/yazi/keymap.toml
   .config/yazi/package.toml
   .config/yazi/yazi.toml
+  .config/zed/keymap.json
   .config/zed/settings.json
   .config/zsh/alias.sh
   .config/zsh/command.sh


### PR DESCRIPTION
## Background / 背景

Zed で Markdown プレビュー（`cmd-shift-v` のレンダリング表示）を読む際、`j`/`k` でスクロールできると読み進めやすい。エディタ表示側は `vim_mode: true` により既に `j`/`k` が効くが、プレビューは `MarkdownPreview` コンテキストで `j`/`k` が未割り当てだった。

## Changes / 変更内容

- `.config/zed/keymap.json` を新規作成し、`MarkdownPreview` コンテキストで `j` → `markdown::ScrollDown` / `k` → `markdown::ScrollUp` をバインド
- `link.sh` の `entries` に `.config/zed/keymap.json` を追加（`~/.config/zed/keymap.json` へ symlink）

## Impact scope / 影響範囲

- Zed の Markdown プレビュー表示のみ。エディタ表示や他ツールへの影響なし
- 新規 keymap.json のため既存キーバインドの上書きなし

## Testing / 動作確認

- [x] `./link.sh` で symlink 作成を確認（`~/.config/zed/keymap.json` → repo）
- [x] Markdown プレビューで `j`/`k` の上下スクロールを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)