### PR TITLE
feat(zed): enable inline diagnostics

### DIFF
--- a/.config/zed/settings.json
+++ b/.config/zed/settings.json
@@ -40,5 +40,10 @@
         }
       }
     }
+  },
+  "diagnostics": {
+    "inline": {
+      "enabled": true
+    }
   }
 }


### PR DESCRIPTION
## Background / 背景

Zed でエラーや警告を確認する際、行末までカーソルを移動したりパネルを開く必要があった。診断メッセージをコード行の右側にインラインで常時表示したい。

## Changes / 変更内容

- `.config/zed/settings.json` に `diagnostics.inline.enabled: true` を追加

## Impact scope / 影響範囲

- Zed の表示のみ。他のツール・設定には影響なし

## Testing / 動作確認

- [x] JSON として妥当（インデントを既存のスペース2に統一）
- [x] Zed で診断がインライン表示されることを確認