### PR TITLE
feat(nvim): add lazy.nvim starter with project management

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -1,4 +1,5 @@
--- Minimal neovim config. No plugin manager, built-ins only.
+-- Neovim config. Plugins managed by lazy.nvim.
+-- Minimal starter: lazy.nvim + neovim-project + telescope + treesitter + mason.
 
 vim.g.mapleader = ' '
 vim.g.maplocalleader = ' '
@@ -38,10 +39,98 @@ opt.timeoutlen = 400
 opt.clipboard = 'unnamedplus'
 opt.completeopt = { 'menuone', 'noselect', 'noinsert' }
 
--- Built-in fuzzy file find via :find
+-- Built-in fuzzy file find via :find (kept as a fallback alongside telescope)
 opt.path:append('**')
 opt.wildmode = 'longest:full,full'
 opt.wildignore:append({ '*/node_modules/*', '*/.git/*', '*/dist/*', '*/build/*' })
+
+-- ===== Bootstrap lazy.nvim =====
+local lazypath = vim.fn.stdpath('data') .. '/lazy/lazy.nvim'
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  vim.fn.system({
+    'git', 'clone', '--filter=blob:none',
+    'https://github.com/folke/lazy.nvim.git', '--branch=stable', lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- init.lua is symlinked from the dotfiles repo; resolve it so the lockfile is
+-- written directly into the repo dir (no symlink -> atomic writes stay safe).
+local repo_config = vim.fn.fnamemodify(vim.fn.resolve(vim.fn.stdpath('config') .. '/init.lua'), ':h')
+
+require('lazy').setup({
+  -- Fuzzy finder ------------------------------------------------------------
+  {
+    'nvim-telescope/telescope.nvim',
+    branch = 'master',
+    dependencies = {
+      'nvim-lua/plenary.nvim',
+      { 'nvim-telescope/telescope-fzf-native.nvim', build = 'make' },
+    },
+    config = function()
+      local telescope = require('telescope')
+      telescope.setup({})
+      telescope.load_extension('fzf')
+    end,
+  },
+
+  -- Project management (Zed-like: pick a dir -> swap session) ---------------
+  {
+    'coffebar/neovim-project',
+    lazy = false,
+    priority = 100,
+    dependencies = {
+      'nvim-lua/plenary.nvim',
+      'nvim-telescope/telescope.nvim',
+      'Shatur/neovim-session-manager',
+    },
+    init = function()
+      -- needed so buffers/layout are stored per project
+      vim.opt.sessionoptions:append('globals')
+    end,
+    opts = {
+      -- Match the workspace conventions from CLAUDE.md
+      projects = {
+        '~/workspaces/*/*',
+        '~/worktrees/*/*/*',
+      },
+      picker = { type = 'telescope' },
+      -- Launch into the cwd, not the last project (predictable, Zed-like)
+      last_session_on_startup = false,
+    },
+  },
+
+  -- Treesitter (main branch; required for Neovim 0.11+ / 0.12) --------------
+  {
+    'nvim-treesitter/nvim-treesitter',
+    branch = 'main',
+    build = ':TSUpdate',
+    config = function()
+      require('nvim-treesitter').install({
+        'lua', 'vim', 'vimdoc', 'bash', 'yaml', 'json',
+        'markdown', 'markdown_inline', 'terraform', 'dockerfile',
+      })
+      -- Highlighting is a built-in feature enabled per filetype.
+      vim.api.nvim_create_autocmd('FileType', {
+        pattern = { 'lua', 'vim', 'help', 'sh', 'bash', 'yaml',
+          'json', 'markdown', 'terraform', 'dockerfile' },
+        callback = function() pcall(vim.treesitter.start) end,
+      })
+    end,
+  },
+
+  -- LSP server installer (binaries only; LSP itself stays native below) ------
+  { 'mason-org/mason.nvim', opts = {} },
+  {
+    'WhoIsSethDaniel/mason-tool-installer.nvim',
+    dependencies = { 'mason-org/mason.nvim' },
+    opts = { ensure_installed = { 'yaml-language-server' } },
+  },
+}, {
+  -- lazy.nvim options
+  lockfile = repo_config .. '/lazy-lock.json',
+  change_detection = { notify = false },
+})
 
 -- ===== Keymaps =====
 local map = vim.keymap.set
@@ -63,10 +152,21 @@ map('n', 'N', 'Nzzzv')
 -- Paste without yanking replaced text
 map('x', '<leader>p', '"_dP')
 
--- File / buffer navigation (built-in)
+-- File explorer (built-in netrw)
 map('n', '<leader>e', '<cmd>Explore<CR>')
-map('n', '<leader>f', ':find ')
-map('n', '<leader>b', ':buffer ')
+
+-- Telescope
+map('n', '<leader>ff', '<cmd>Telescope find_files<CR>', { desc = 'Find files' })
+map('n', '<leader>fg', '<cmd>Telescope live_grep<CR>', { desc = 'Live grep' })
+map('n', '<leader>fb', '<cmd>Telescope buffers<CR>', { desc = 'Buffers' })
+map('n', '<leader>fh', '<cmd>Telescope help_tags<CR>', { desc = 'Help tags' })
+map('n', '<leader>fd', '<cmd>Telescope diagnostics<CR>', { desc = 'Diagnostics' })
+
+-- Projects (Zed cmd+opt+o equivalent)
+map('n', '<leader>fp', '<cmd>NeovimProjectDiscover<CR>', { desc = 'Discover projects' })
+map('n', '<leader>fP', '<cmd>NeovimProjectHistory<CR>', { desc = 'Recent projects' })
+
+-- Buffer cycling
 map('n', '[b', '<cmd>bprevious<CR>')
 map('n', ']b', '<cmd>bnext<CR>')
 
@@ -90,8 +190,9 @@ vim.api.nvim_create_autocmd('BufWritePre', {
   end,
 })
 
--- ===== LSP =====
--- yaml-language-server (Kubernetes schema scoped to bons8i-style kustomize layout)
+-- ===== LSP (native, nvim 0.11+) =====
+-- yaml-language-server binary is installed by mason (its bin dir is on PATH).
+-- Kubernetes schema scoped to bons8i-style kustomize layout.
 vim.lsp.config('yamlls', {
   cmd = { 'yaml-language-server', '--stdio' },
   filetypes = { 'yaml' },

--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -1,0 +1,11 @@
+{
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "mason-tool-installer.nvim": { "branch": "main", "commit": "443f1ef8b5e6bf47045cb2217b6f748a223cf7dc" },
+  "mason.nvim": { "branch": "main", "commit": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d" },
+  "neovim-project": { "branch": "main", "commit": "f4e9b3392dc46b6e615b629a40ea4fa47cc2a203" },
+  "neovim-session-manager": { "branch": "master", "commit": "89d253a6c68af60b49570044591d5b8701866601" },
+  "nvim-treesitter": { "branch": "main", "commit": "7248feaca45e4d944591497964bc19afa89ad1c6" },
+  "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "telescope-fzf-native.nvim": { "branch": "main", "commit": "b25b749b9db64d375d782094e2b9dce53ad53a40" },
+  "telescope.nvim": { "branch": "master", "commit": "427b576c16792edad01a92b89721d923c19ad60f" }
+}

--- a/Brewfile
+++ b/Brewfile
@@ -13,6 +13,7 @@ brew "atuin"
 
 # Editor
 brew "neovim"
+brew "tree-sitter-cli" # nvim-treesitter (main branch) compiles parsers with this
 
 # Development
 brew "gh"


### PR DESCRIPTION
## Background / 背景

エディタ戦略 (docs/editor-strategy.md) では nvim を built-ins only の最小ツールに留める判断をしたが、主力エディタとして一度実際に試さないと判断できないため、再トライアルを開始する。2026-07 に一度構築して破棄した lazy.nvim 構成を復元した。

## Changes / 変更内容

- `.config/nvim/init.lua`: lazy.nvim ベースのプラグイン構成に変更
  - telescope.nvim (+ telescope-fzf-native / plenary): ファジー検索（`Space f f/g/b/h/d`）
  - coffebar/neovim-project (+ neovim-session-manager): Zed 的なプロジェクト切替（`Space f p` / `Space f P`）
  - nvim-treesitter (main ブランチ): シンタックスハイライト
  - mason.nvim + mason-tool-installer: LSP バイナリ管理（yaml-language-server 自動導入）
  - 既存の options / keymaps / native LSP (yamlls + Kubernetes schema) は維持
- `.config/nvim/lazy-lock.json`: プラグインの commit をピン留めする lockfile（新規）
- `Brewfile`: `tree-sitter-cli` 追加（treesitter main ブランチのパーサコンパイルに必要。`tree-sitter` formula はライブラリのみで別物）

## Impact scope / 影響範囲

- nvim の起動構成のみ。初回起動時に lazy.nvim がプラグインを `~/.local/share/nvim/lazy/` へ clone する
- init.lua の symlink 運用は維持（lockfile は symlink を解決して repo 側に書き込む）
- yaml-language-server が brew と mason の二重管理になる（nvim 内では mason 側が優先、実害なし。トライアル定着後にどちらかへ寄せる）

## Testing / 動作確認

- [x] `bats tests` 全 22 件パス / All 22 bats tests pass
- [x] `nvim --headless '+Lazy! sync'` で 9 プラグイン全インストール成功
- [x] treesitter パーサ 11 種（lua/yaml/terraform 等 + 依存 hcl）コンパイル成功
- [x] mason 経由で yaml-language-server 導入成功
- [x] YAML ファイルを開いて yamlls がアタッチすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)