### PR TITLE
feat(nvim): add colorscheme, LSP, and fix treesitter highlighting

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -59,6 +59,15 @@ vim.opt.rtp:prepend(lazypath)
 local repo_config = vim.fn.fnamemodify(vim.fn.resolve(vim.fn.stdpath('config') .. '/init.lua'), ':h')
 
 require('lazy').setup({
+  -- Colorscheme (kanagawa; muted wabi-sabi palette) -------------------------
+  {
+    'rebelot/kanagawa.nvim',
+    priority = 1000, -- load before everything so early UI is themed
+    config = function()
+      vim.cmd.colorscheme('kanagawa')
+    end,
+  },
+
   -- Fuzzy finder ------------------------------------------------------------
   {
     'nvim-telescope/telescope.nvim',
@@ -109,23 +118,19 @@ require('lazy').setup({
       require('nvim-treesitter').install({
         'lua', 'vim', 'vimdoc', 'bash', 'yaml', 'json',
         'markdown', 'markdown_inline', 'terraform', 'dockerfile',
+        'javascript', 'typescript', 'tsx', 'rust', 'go', 'python',
       })
-      -- Highlighting is a built-in feature enabled per filetype.
+      -- Highlighting is a built-in feature enabled per filetype. Start it for
+      -- any filetype whose parser is installed; pcall no-ops when there is none,
+      -- so the install list above is the single source of truth.
       vim.api.nvim_create_autocmd('FileType', {
-        pattern = { 'lua', 'vim', 'help', 'sh', 'bash', 'yaml',
-          'json', 'markdown', 'terraform', 'dockerfile' },
         callback = function() pcall(vim.treesitter.start) end,
       })
     end,
   },
 
-  -- LSP server installer (binaries only; LSP itself stays native below) ------
-  { 'mason-org/mason.nvim', opts = {} },
-  {
-    'WhoIsSethDaniel/mason-tool-installer.nvim',
-    dependencies = { 'mason-org/mason.nvim' },
-    opts = { ensure_installed = { 'yaml-language-server' } },
-  },
+  -- LSP servers are installed via brew (Brewfile) / mise (.mise.toml), not a
+  -- plugin. The native client below launches them off $PATH.
 }, {
   -- lazy.nvim options
   lockfile = repo_config .. '/lazy-lock.json',
@@ -191,7 +196,7 @@ vim.api.nvim_create_autocmd('BufWritePre', {
 })
 
 -- ===== LSP (native, nvim 0.11+) =====
--- yaml-language-server binary is installed by mason (its bin dir is on PATH).
+-- yaml-language-server binary comes from brew (Brewfile); it is on $PATH.
 -- Kubernetes schema scoped to bons8i-style kustomize layout.
 vim.lsp.config('yamlls', {
   cmd = { 'yaml-language-server', '--stdio' },
@@ -213,6 +218,23 @@ vim.lsp.config('yamlls', {
   },
 })
 vim.lsp.enable('yamlls')
+
+-- Servers below come from brew (Brewfile) / mise (.mise.toml); all on $PATH:
+--   rust-analyzer -> mise | typescript-language-server -> brew
+vim.lsp.config('rust_analyzer', {
+  cmd = { 'rust-analyzer' },
+  filetypes = { 'rust' },
+  root_markers = { 'Cargo.toml', 'Cargo.lock', '.git' },
+})
+vim.lsp.config('ts_ls', {
+  cmd = { 'typescript-language-server', '--stdio' },
+  filetypes = {
+    'javascript', 'javascriptreact', 'javascript.jsx',
+    'typescript', 'typescriptreact', 'typescript.tsx',
+  },
+  root_markers = { 'tsconfig.json', 'jsconfig.json', 'package.json', '.git' },
+})
+vim.lsp.enable({ 'rust_analyzer', 'ts_ls' })
 
 vim.api.nvim_create_autocmd('LspAttach', {
   group = augroup,

--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -1,7 +1,6 @@
 {
+  "kanagawa.nvim": { "branch": "master", "commit": "bb85e4bfc8d89b0e62c8fa53ccdd13d12e2f77b3" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
-  "mason-tool-installer.nvim": { "branch": "main", "commit": "443f1ef8b5e6bf47045cb2217b6f748a223cf7dc" },
-  "mason.nvim": { "branch": "main", "commit": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d" },
   "neovim-project": { "branch": "main", "commit": "f4e9b3392dc46b6e615b629a40ea4fa47cc2a203" },
   "neovim-session-manager": { "branch": "master", "commit": "89d253a6c68af60b49570044591d5b8701866601" },
   "nvim-treesitter": { "branch": "main", "commit": "7248feaca45e4d944591497964bc19afa89ad1c6" },

--- a/Brewfile
+++ b/Brewfile
@@ -19,7 +19,7 @@ brew "tree-sitter-cli" # nvim-treesitter (main branch) compiles parsers with thi
 brew "gh"
 brew "git-delta"
 brew "tmux"
-brew "typescript-language-server"
+brew "typescript-language-server" # LSP: js/ts (nvim)
 brew "crit"
 
 # Kubernetes / YAML


### PR DESCRIPTION
## Background / 背景

nvim で `.js` / `.rs` / `.tf` などを開いても文字が白いまま（シンタックスハイライトが効かない）状態だった。調査の結果、初回セットアップ時の treesitter パーサーインストールが中断され、中途半端な runtime 状態（tarball・revision マーカー・queries シンボリックリンク）が残って再コンパイルが永久にスキップされていたことが原因と判明。あわせて、Zed 並みの見た目・補完体験に近づけるため colorscheme と LSP を整備し、重複していた mason を撤去する。

## Changes / 変更内容

- **treesitter ハイライト修復**: パーサー未コンパイル問題を解消し、`javascript` / `typescript` / `tsx` / `rust` / `go` / `python` を install リストに追加
- **ハイライト発火の汎用化**: FileType autocmd を「パーサーがある filetype は全て `vim.treesitter.start()`」に変更し、install リストを単一の管理点に
- **colorscheme 追加**: `kanagawa`（wave）を導入
- **LSP 設定追加**: `rust_analyzer`（mise）と `ts_ls`（brew）を nvim-native の `vim.lsp.config` + `vim.lsp.enable` で設定。go/python は現状開発しないため見送り
- **mason 撤去**: `mason.nvim` + `mason-tool-installer.nvim` を削除。language server は brew（Brewfile）/ mise（.mise.toml）で管理し PATH ベースで起動（既存の brew/mise 資産と重複していたため）
- **Brewfile**: `typescript-language-server` に用途コメントを追記

## Impact scope / 影響範囲

- `.config/nvim/init.lua` / `.config/nvim/lazy-lock.json` / `Brewfile`
- nvim の見た目とエディタ体験のみ。他ツール・シェル・CI への影響なし
- LSP サーバーのバイナリはすべて既存の brew/mise 導入物（新規の追加インストールは無し）

## Testing / 動作確認

- [x] treesitter が `.tf` / `.js` / `.mjs` / `.ts` / `.rs` でアタッチすることを headless 検証（`ts_active=true`）
- [x] kanagawa（wave）適用を highlight group の配色で確認
- [x] mason 削除後も yamlls が `.git` プロジェクトでアタッチすることを確認
- [x] rust_analyzer / ts_ls がプロジェクトマーカー付きディレクトリでアタッチすることを確認
- [x] config が headless でエラーなくロードすることを確認