### PR TITLE
feat(nvim): show hidden files in telescope pickers

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -78,7 +78,25 @@ require('lazy').setup({
     },
     config = function()
       local telescope = require('telescope')
-      telescope.setup({})
+      telescope.setup({
+        defaults = {
+          -- include dotfiles (e.g. .config) but skip the .git directory
+          file_ignore_patterns = { '^%.git/' },
+          vimgrep_arguments = {
+            'rg',
+            '--color=never',
+            '--no-heading',
+            '--with-filename',
+            '--line-number',
+            '--column',
+            '--smart-case',
+            '--hidden',
+          },
+        },
+        pickers = {
+          find_files = { hidden = true },
+        },
+      })
       telescope.load_extension('fzf')
     end,
   },


### PR DESCRIPTION
## Background / 背景

telescope の `find_files` / `live_grep` はデフォルトでドット始まりの隠しファイルを表示対象から除外する。`.config` 配下など dotfiles リポジトリでは隠しファイルこそ主対象であり、検索できないと不便だった。

## Changes / 変更内容

- `pickers.find_files.hidden = true` を設定し、`find_files` でドット始まりファイルを表示
- `defaults.vimgrep_arguments` に `--hidden` を追加し、`live_grep` でも隠しファイル内を grep 対象に含める
- `defaults.file_ignore_patterns = { '^%.git/' }` で `.git/` 配下だけは除外（オブジェクトファイルのノイズを防ぐ）

## Impact scope / 影響範囲

- Neovim の telescope による `<leader>ff`（find_files）と `<leader>fg`（live_grep）の検索対象のみ
- `.git/` 配下は引き続き非表示

## Testing / 動作確認

- [x] `nvim --headless` で設定がエラーなくロードされることを確認
- [x] `vimgrep_arguments` に `--hidden` が含まれることを確認
- [x] `file_ignore_patterns` が `{ '^%.git/' }` になっていることを確認
- [x] `fzf` 拡張が正常にロードされることを確認