### PR TITLE
feat(neovide): adopt neovide as nvim GUI frontend

### DIFF
--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -5104,7 +5104,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5146,7 +5147,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5188,7 +5190,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5230,7 +5233,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5272,7 +5276,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5314,7 +5319,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5356,7 +5362,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5398,7 +5405,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5440,7 +5448,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5482,7 +5491,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5524,7 +5534,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5566,7 +5577,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5608,7 +5620,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5650,7 +5663,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5692,7 +5706,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5734,7 +5749,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5776,7 +5792,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5818,7 +5835,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5860,7 +5878,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5902,7 +5921,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5944,7 +5964,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -5986,7 +6007,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6028,7 +6050,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6070,7 +6093,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6112,7 +6136,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6154,7 +6179,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6196,7 +6222,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6238,7 +6265,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6280,7 +6308,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6322,7 +6351,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6364,7 +6394,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6406,7 +6437,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6448,7 +6480,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6490,7 +6523,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6532,7 +6566,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6574,7 +6609,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6616,7 +6652,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6658,7 +6695,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6700,7 +6738,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6742,7 +6781,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6784,7 +6824,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6826,7 +6867,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6868,7 +6910,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6910,7 +6953,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6952,7 +6996,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -6994,7 +7039,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7036,7 +7082,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7078,7 +7125,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7120,7 +7168,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7162,7 +7211,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7204,7 +7254,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7246,7 +7297,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7288,7 +7340,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7330,7 +7383,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7372,7 +7426,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7414,7 +7469,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7456,7 +7512,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7498,7 +7555,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]
@@ -7539,7 +7597,8 @@
                       "^com\\.mitchellh\\.ghostty$",
                       "^net\\.kovidgoyal\\.kitty$",
                       "^com\\.google\\.Chrome$",
-                      "^dev\\.zed\\.Zed$"
+                      "^dev\\.zed\\.Zed$",
+                      "^com\\.neovide\\.neovide$"
                     ]
                   }
                 ]

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -19,6 +19,7 @@ const VIM_APP_IDS = [
   ...TERMINAL_BUNDLE_IDS,
   '^com\\.google\\.Chrome$',
   '^dev\\.zed\\.Zed$',
+  '^com\\.neovide\\.neovide$',
 ] as const;
 const unlessVimApp = ifApp({
   bundle_identifiers: [...VIM_APP_IDS],

--- a/.config/neovide/config.toml
+++ b/.config/neovide/config.toml
@@ -1,0 +1,5 @@
+# Neovide global settings. Neovim behaviour itself lives in ../nvim/init.lua
+# (read as-is via the `if vim.g.neovide` guard); this file is GUI-only.
+
+# Frameless window (no title bar / traffic-light buttons).
+frame = "none"

--- a/Brewfile
+++ b/Brewfile
@@ -32,5 +32,6 @@ brew "mise"
 
 # GUI Apps
 cask "ghostty"
+cask "neovide-app"
 cask "zed"
 cask "font-hack-nerd-font"

--- a/link.sh
+++ b/link.sh
@@ -11,6 +11,7 @@ entries=(
   .config/ghostty/config
   .config/karabiner/HRM.md
   .config/karabiner/karabiner.json
+  .config/neovide/config.toml
   .config/nvim/init.lua
   .config/sheldon/plugins.toml
   .config/tmux/yazi-picker.sh


### PR DESCRIPTION
## Background / 背景

nvim 主力化トライアルの一環として neovide（nvim の GUI フロントエンド）を試用し、描画・入力体験が良好だったため正式採用する。neovim の設定は従来どおり `nvim/init.lua` を共有し、neovide には GUI 専用の設定のみを持たせる。

## Changes / 変更内容

- **Brewfile**: `cask "neovide-app"` を追加（homebrew/cask 公式トークン。`neovide` はそのエイリアス）
- **config**: `.config/neovide/config.toml` を新規作成。`frame = "none"` で frameless ウィンドウ化。neovim の挙動そのものは `nvim/init.lua` を共有し、この TOML は GUI 専用
- **link.sh**: entries に `.config/neovide/config.toml` を追加し symlink 管理下に置く
- **Karabiner**: vim アプリ除外リストに `com.neovide.neovide` を追加。右人差し指 `J` の Home Row Mod（Shift）を無効化し、vim の `j` 長押しスクロールが効くようにする（生成物 `karabiner.json` も更新）

## Impact scope / 影響範囲

- 新規 GUI アプリの追加。既存のターミナル nvim（ghostty + tmux）運用には影響なし（`config.toml` は neovide 起動時のみ読まれる）
- Karabiner: neovide 内でのみ `J` の HRM が無効化される。他アプリの挙動は不変

## Testing / 動作確認

- [x] `brew bundle check` で neovide-app が satisfied と認識される（未満足は無関係の mise のみ）
- [x] `./link.sh` で `~/.config/neovide/config.toml` の symlink 作成を確認
- [x] neovide 再起動で frameless ウィンドウ表示を確認
- [x] `cd .config/karabiner && bun run build` 成功、プロファイル reload 済み。neovide 内で `J` 連打スクロールが動作
- [x] karabiner.json の差分が neovide bundle id 追加のみであることを確認