### PR TITLE
feat(nvim): adopt oil.nvim as file explorer

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -127,6 +127,19 @@ require('lazy').setup({
     },
   },
 
+  -- File explorer (edit the filesystem like a buffer) ----------------------
+  {
+    'stevearc/oil.nvim',
+    lazy = false, -- so it can hijack netrw and open directories on startup
+    opts = {
+      -- Take over netrw so `:e <dir>` and `<leader>e` open oil, not netrw
+      default_file_explorer = true,
+      view_options = {
+        show_hidden = true, -- match telescope find_files (hidden = true)
+      },
+    },
+  },
+
   -- Treesitter (main branch; required for Neovim 0.11+ / 0.12) --------------
   {
     'nvim-treesitter/nvim-treesitter',
@@ -175,8 +188,9 @@ map('n', 'N', 'Nzzzv')
 -- Paste without yanking replaced text
 map('x', '<leader>p', '"_dP')
 
--- File explorer (built-in netrw)
-map('n', '<leader>e', '<cmd>Explore<CR>')
+-- File explorer (oil.nvim: edit the filesystem like a buffer)
+map('n', '<leader>e', '<cmd>Oil<CR>', { desc = 'Open parent dir (oil)' })
+map('n', '-', '<cmd>Oil<CR>', { desc = 'Open parent dir (oil)' })
 
 -- Telescope
 map('n', '<leader>ff', '<cmd>Telescope find_files<CR>', { desc = 'Find files' })

--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -4,6 +4,7 @@
   "neovim-project": { "branch": "main", "commit": "f4e9b3392dc46b6e615b629a40ea4fa47cc2a203" },
   "neovim-session-manager": { "branch": "master", "commit": "89d253a6c68af60b49570044591d5b8701866601" },
   "nvim-treesitter": { "branch": "main", "commit": "7248feaca45e4d944591497964bc19afa89ad1c6" },
+  "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
   "telescope-fzf-native.nvim": { "branch": "main", "commit": "b25b749b9db64d375d782094e2b9dce53ad53a40" },
   "telescope.nvim": { "branch": "master", "commit": "427b576c16792edad01a92b89721d923c19ad60f" }


### PR DESCRIPTION
## Background / 背景

nvim（neovide 含む）でのファイル・ディレクトリ作成が組み込みの netrw ベースで、操作感が直感的でなかった。バッファを編集する感覚でファイル操作できる oil.nvim を導入する。

## Changes / 変更内容

- `stevearc/oil.nvim` を lazy.nvim のプラグインとして追加
  - `default_file_explorer = true` で netrw を置き換え（`:e <dir>` も oil で開く）
  - `show_hidden = true` で telescope の `find_files`（hidden = true）と隠しファイルの表示を揃えた
- キーマップ変更: `<leader>e` を `:Explore`（netrw）から `:Oil` に付け替え、慣例の `-`（親ディレクトリを開く）を追加
- `lazy-lock.json` に oil.nvim を追記

## Impact scope / 影響範囲

- nvim のファイラー操作のみ。`<leader>e` の遷移先が netrw から oil に変わる
- 他のプラグイン・LSP・キーマップには影響なし
- lazy-lock.json は oil.nvim の追加のみ（無関係な依存更新は含めていない）

## Testing / 動作確認

- [x] `nvim --headless "+Lazy! sync" +qa` で oil.nvim がインストールされることを確認
- [x] `require('oil')` がエラーなくロードできることを確認（oil loadable: true）
- [x] repo 側 `lazy-lock.json` に oil.nvim エントリが追記されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)