### PR TITLE
feat(zed): add vim g[ / g] tab navigation

### DIFF
--- a/.config/zed/keymap.json
+++ b/.config/zed/keymap.json
@@ -18,8 +18,8 @@
   {
     "context": "vim_mode == normal || vim_mode == visual",
     "bindings": {
-      "g t": "pane::ActivateNextItem",
-      "g shift-t": "pane::ActivatePreviousItem"
+      "g ]": "pane::ActivateNextItem",
+      "g [": "pane::ActivatePreviousItem"
     }
   }
 ]

--- a/.config/zed/keymap.json
+++ b/.config/zed/keymap.json
@@ -13,5 +13,13 @@
       "j": "markdown::ScrollDown",
       "k": "markdown::ScrollUp"
     }
+  },
+  // ファイルタブ移動を vim 流に（cmd-shift-[ / ] の置き換え）
+  {
+    "context": "vim_mode == normal || vim_mode == visual",
+    "bindings": {
+      "g t": "pane::ActivateNextItem",
+      "g shift-t": "pane::ActivatePreviousItem"
+    }
   }
 ]


### PR DESCRIPTION
## Background / 背景

Zed のファイルタブ移動が既定の `cmd-shift-[` / `cmd-shift-]` で、小指 Shift + ブラケットへの運指が手首負担になっていた。vim mode を有効にしているので、vim 流のタブ移動を割り当てて負担を下げる。当初 `gt` / `gT` にしたが、`g` を押しながら `t` に伸ばす運指が押しにくかったため `g[` / `g]` に変更した。

## Changes / 変更内容

- `keymap.json` に vim normal / visual コンテキストのバインドを追加
  - `g ]` → `pane::ActivateNextItem`（次のタブ）
  - `g [` → `pane::ActivatePreviousItem`（前のタブ）

## Impact scope / 影響範囲

- Zed の vim normal / visual モードでのタブ移動のみ
- 既定の `cmd-shift-[` / `cmd-shift-]` はそのまま残るため併用可能
- 他のキーマップ・設定には影響なし

## Testing / 動作確認

- [x] コメント除去後の JSON が妥当であることを確認
- [x] Zed ノーマルモードで `g[` / `g]` によりタブが前後に切り替わることを確認