### PR TITLE
feat(zed): switch tab navigation to opt-[ / opt-]

### DIFF
--- a/.config/zed/keymap.json
+++ b/.config/zed/keymap.json
@@ -14,12 +14,14 @@
       "k": "markdown::ScrollUp"
     }
   },
-  // ファイルタブ移動を vim 流に（cmd-shift-[ / ] の置き換え）
+  // ファイルタブ移動（cmd-shift-[ / ] の置き換え）
+  // Opt を押しっぱなしにして [ / ] を連打・長押しすれば連続移動できる
+  // （Opt は Karabiner HRM の s ホールドでも出せる）
   {
     "context": "vim_mode == normal || vim_mode == visual",
     "bindings": {
-      "g ]": "pane::ActivateNextItem",
-      "g [": "pane::ActivatePreviousItem"
+      "alt-]": "pane::ActivateNextItem",
+      "alt-[": "pane::ActivatePreviousItem"
     }
   }
 ]


### PR DESCRIPTION
## Background / 背景

前回 #180 で追加した `g[` / `g]` によるタブ移動は、1 タブごとに `g` を押し直す必要があり、たくさんのファイルを開いている状態で複数タブを跨いで移動するのが重かった。

`g` は普通のキーなので押しっぱなしにしても修飾キー状態にはならず（`g g g...` とリピート入力されるだけ）、「プレフィックスを押しっぱなしで連続移動」は vim 流のシーケンスバインドでは実現できない。そのため修飾キー版のバインドに置き換える。

## Changes / 変更内容

- `keymap.json` の vim normal / visual バインドを差し替え
  - `g ]` / `g [` を削除
  - `alt-]` → `pane::ActivateNextItem`（次のタブ）
  - `alt-[` → `pane::ActivatePreviousItem`（前のタブ）
- 運指の意図をコメントに記載（Opt は Karabiner HRM の `s` ホールドで出せる）

Opt を押しっぱなしにしたままブラケットを連打、またはブラケット長押し（キーリピート）で連続移動できる。

## Impact scope / 影響範囲

- Zed の vim normal / visual モードでのタブ移動のみ
- 既定の `cmd-shift-[` / `cmd-shift-]` はそのまま残るため併用可能
- Zed 既定の `alt-[` / `alt-]`（`editor::PreviousEditPrediction` / `NextEditPrediction`）は `edit_prediction` コンテキスト限定かつユーザー keymap が優先されるため実害なし
- 他のキーマップ・設定には影響なし

## Testing / 動作確認

- [x] コメント除去後の JSON が妥当であることを確認
- [x] Zed ノーマルモードで `opt-[` / `opt-]` によりタブが前後に切り替わることを確認
- [x] Opt 押しっぱなしでのブラケット連打・長押しで連続移動できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)