### PR TITLE
feat(nvim): make keymaps discoverable via picker

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -164,22 +164,22 @@ require('lazy').setup({
 -- ===== Keymaps =====
 local map = vim.keymap.set
 
-map('n', '<Esc>', '<cmd>nohlsearch<CR>')
+map('n', '<Esc>', '<cmd>nohlsearch<CR>', { desc = 'Clear search highlight' })
 
 -- Window navigation
-map('n', '<C-h>', '<C-w>h')
-map('n', '<C-j>', '<C-w>j')
-map('n', '<C-k>', '<C-w>k')
-map('n', '<C-l>', '<C-w>l')
+map('n', '<C-h>', '<C-w>h', { desc = 'Window left' })
+map('n', '<C-j>', '<C-w>j', { desc = 'Window down' })
+map('n', '<C-k>', '<C-w>k', { desc = 'Window up' })
+map('n', '<C-l>', '<C-w>l', { desc = 'Window right' })
 
 -- Center cursor on big jumps / search
-map('n', '<C-d>', '<C-d>zz')
-map('n', '<C-u>', '<C-u>zz')
-map('n', 'n', 'nzzzv')
-map('n', 'N', 'Nzzzv')
+map('n', '<C-d>', '<C-d>zz', { desc = 'Half page down (centered)' })
+map('n', '<C-u>', '<C-u>zz', { desc = 'Half page up (centered)' })
+map('n', 'n', 'nzzzv', { desc = 'Next search match (centered)' })
+map('n', 'N', 'Nzzzv', { desc = 'Prev search match (centered)' })
 
 -- Paste without yanking replaced text
-map('x', '<leader>p', '"_dP')
+map('x', '<leader>p', '"_dP', { desc = 'Paste over selection (keep register)' })
 
 -- File explorer (oil.nvim: edit the filesystem like a buffer)
 map('n', '<leader>e', '<cmd>Oil<CR>', { desc = 'Open parent dir (oil)' })
@@ -191,17 +191,17 @@ map('n', '<leader>fg', function() Snacks.picker.grep() end, { desc = 'Live grep'
 map('n', '<leader>fb', function() Snacks.picker.buffers() end, { desc = 'Buffers' })
 map('n', '<leader>fh', function() Snacks.picker.help() end, { desc = 'Help tags' })
 map('n', '<leader>fd', function() Snacks.picker.diagnostics() end, { desc = 'Diagnostics' })
+-- Self-documentation: search every keymap / ex-command by its desc, run with <CR>.
+-- Every map below carries a desc so these two stay useful.
+map('n', '<leader>fk', function() Snacks.picker.keymaps() end, { desc = 'Keymaps (search what is bound)' })
+map('n', '<leader>fc', function() Snacks.picker.commands() end, { desc = 'Ex commands' })
 
 -- Projects (Zed cmd+opt+o equivalent)
 map('n', '<leader>fp', '<cmd>NeovimProjectDiscover<CR>', { desc = 'Discover projects' })
 map('n', '<leader>fP', '<cmd>NeovimProjectHistory<CR>', { desc = 'Recent projects' })
 
--- Buffer cycling
-map('n', '[b', '<cmd>bprevious<CR>')
-map('n', ']b', '<cmd>bnext<CR>')
-
-map('n', '<leader>w', '<cmd>write<CR>')
-map('n', '<leader>q', '<cmd>quit<CR>')
+map('n', '<leader>w', '<cmd>write<CR>', { desc = 'Write file' })
+map('n', '<leader>q', '<cmd>quit<CR>', { desc = 'Quit window' })
 
 -- ===== Autocommands =====
 local augroup = vim.api.nvim_create_augroup('user', { clear = true })
@@ -218,6 +218,17 @@ vim.api.nvim_create_autocmd('BufWritePre', {
     vim.cmd([[keeppatterns %s/\s\+$//e]])
     vim.fn.winrestview(save)
   end,
+})
+
+-- ===== Diagnostics =====
+-- virtual_text is off by default, so show the message on jump instead. This hooks
+-- Neovim's own [d / ]d maps; do not re-map those keys here.
+vim.diagnostic.config({
+  jump = {
+    on_jump = function(_, bufnr)
+      vim.diagnostic.open_float({ bufnr = bufnr, scope = 'cursor' })
+    end,
+  },
 })
 
 -- ===== LSP (native, nvim 0.11+) =====
@@ -265,14 +276,16 @@ vim.api.nvim_create_autocmd('LspAttach', {
   group = augroup,
   callback = function(args)
     local buf = args.buf
-    local opts = { buffer = buf }
-    map('n', 'K', vim.lsp.buf.hover, opts)
-    map('n', 'gd', vim.lsp.buf.definition, opts)
-    map('n', '<leader>rn', vim.lsp.buf.rename, opts)
-    map('n', '<leader>ca', vim.lsp.buf.code_action, opts)
-    map('n', '[d', function() vim.diagnostic.jump({ count = -1, float = true }) end, opts)
-    map('n', ']d', function() vim.diagnostic.jump({ count = 1, float = true }) end, opts)
-    map('n', '<leader>d', vim.diagnostic.open_float, opts)
+    local function lmap(lhs, rhs, desc)
+      map('n', lhs, rhs, { buffer = buf, desc = 'LSP: ' .. desc })
+    end
+    -- references / implementation / type definition / document symbol are already
+    -- mapped by Neovim itself (grr / gri / grt / gO) -- see :h lsp-defaults.
+    lmap('K', vim.lsp.buf.hover, 'Hover docs')
+    lmap('gd', vim.lsp.buf.definition, 'Go to definition')
+    lmap('<leader>rn', vim.lsp.buf.rename, 'Rename symbol')
+    lmap('<leader>ca', vim.lsp.buf.code_action, 'Code action')
+    lmap('<leader>d', vim.diagnostic.open_float, 'Show diagnostic under cursor')
     vim.lsp.completion.enable(true, args.data.client_id, buf, { autotrigger = true })
   end,
 })


### PR DESCRIPTION
## Background / 背景

nvim のキーマップを覚えきれず、「あの操作はどのキーだったか」を毎回思い出せない状態だった。プラグインを足さずに解決したい（`which-key.nvim` は今回見送り）。

調べたところ、`snacks.nvim` は既に導入済みで `keymaps` / `commands` ピッカーを持っており、追加インストールなしで「今バインドされているキーを検索する」体験が作れることが分かった。ただしピッカーは `desc` を頼りに検索するため、`desc` の無いマップは実質引けない。

## Changes / 変更内容

**キーマップの自己文書化**

- `<leader>fk` → `Snacks.picker.keymaps()` を追加。バインド済みの全キーを `desc` でファジー検索し、`<CR>` でそのまま実行できる
- `<leader>fc` → `Snacks.picker.commands()` を追加（Ex コマンド検索）
- `desc` が欠けていた全マップに `desc` を付与
- LSP マップは `lmap(lhs, rhs, desc)` ローカル関数に切り出し、`LSP:` プレフィックスを自動付与。ピッカーで `lsp` と打てば LSP 操作だけに絞り込める。`desc` の付け忘れも構造的に防げる

**nvim デフォルトと重複していたマップの削除**

`:verbose nmap` で定義元を追跡し、以下が `vim/_core/defaults.lua` と重複していることを確認したため削除した。

| 削除したマップ | 重複相手 |
| --- | --- |
| `[b` / `]b` (`:bprevious` / `:bnext`) | `defaults.lua:414`（vim-unimpaired 相当が nvim 0.11 で本体入り）と完全に同一 |
| `[d` / `]d` (`vim.diagnostic.jump`) | `defaults.lua:263`。差分は `float = true` のみ |

`[d` / `]d` の `float = true`（ジャンプ先の診断内容をポップアップ）は診断の `virtual_text` が既定 off のため実質必須。これをキーマップ側ではなく `vim.diagnostic.config({ jump = { on_jump = ... } })` に移し、`vim.diagnostic.jump()` 全体の既定挙動として定義した。

## Impact scope / 影響範囲

`.config/nvim/init.lua` のみ。ローカルの nvim 設定であり、他のツール・スクリプト・CI には影響しない。

挙動の変化:

- `[b` / `]b` / `[d` / `]d` は nvim 本体のマップに委譲される。キー自体は変わらず動く
- 委譲により機能が増える方向の差分のみ:
  - `5]d` のようなカウント指定ジャンプが効くようになる（自作版は常に 1 件ずつ）
  - `[D` / `]D`（ファイル内の最初 / 最後の診断へジャンプ）も float 表示になる
  - `[d` / `]d` が LSP 非アタッチのバッファでも効く（従来は `LspAttach` 内定義のため効かなかった）
- `<leader>fk` の一覧上、これらは本体由来の `desc`（`:bprevious` 等）で表示される

## Testing / 動作確認

- [x] `nvim --headless` で起動エラーが無いことを確認
- [x] `<leader>fk` / `<leader>fc` が `desc` 付きで登録されていることを `nmap <leader>f` で確認
- [x] TypeScript ファイルで `ts_ls` をアタッチさせ、`gd` / `<leader>rn` / `<leader>d` がバッファローカル（`@` マーク）かつ `LSP:` プレフィックス付き `desc` で登録されることを確認
- [x] 削除後の `[b` / `]d` の定義元が `vim/_core/defaults` に戻っていることを `verbose nmap` で確認
- [x] `vim.diagnostic.config().jump.on_jump` が function として登録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)