### PR TITLE
feat(nvim): add which-key.nvim for keymap hints

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -94,6 +94,31 @@ require('lazy').setup({
     },
   },
 
+  -- Keymap hints (popup of what is bound under the prefix just typed) -------
+  {
+    'folke/which-key.nvim',
+    event = 'VeryLazy',
+    opts = {
+      preset = 'modern',
+      -- Mappings without a desc are noise here (and unsearchable in the picker).
+      filter = function(mapping)
+        return mapping.desc ~= nil and mapping.desc ~= ''
+      end,
+      spec = {
+        { '<leader>c', group = 'code' },
+        { '<leader>f', group = 'find' },
+        { '<leader>r', group = 'refactor' },
+      },
+    },
+    keys = {
+      {
+        '<leader>?',
+        function() require('which-key').show({ global = false }) end,
+        desc = 'Buffer-local keymaps',
+      },
+    },
+  },
+
   -- Project management (Zed-like: pick a dir -> swap session) ---------------
   {
     'coffebar/neovim-project',

--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -7,5 +7,6 @@
   "nvim-treesitter": { "branch": "main", "commit": "61df84986b4b4ec469ee745a182e433d49f8c27e" },
   "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
   "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
-  "snacks.nvim": { "branch": "main", "commit": "882c996cf28183f4d63640de0b4c02ec886d01f2" }
+  "snacks.nvim": { "branch": "main", "commit": "882c996cf28183f4d63640de0b4c02ec886d01f2" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }


### PR DESCRIPTION
## Background / 背景

#183 でキーマップに `desc` を付け、`<leader>fk`（`Snacks.picker.keymaps()`）で「何がバインドされているか」を検索できるようにした。ただしこれは**思い出せないと気づいた時に自分で引く**操作であり、キーを打とうとした流れの中では出てこない。

`which-key.nvim` は prefix を押して待つだけでポップアップが出るため、「そもそも覚える必要がない」状態になる。#183 の時点では見送っていたが、導入する判断に変えた。

## Changes / 変更内容

`folke/which-key.nvim` を追加（`event = 'VeryLazy'`）。

**オプション**

| 設定 | 値 | 理由 |
| --- | --- | --- |
| `preset` | `modern` | 画面下部に枠付きで表示。`helix` は右側に縦長で出てコードを隠すため、単一画面 / maximize 運用では下部の方が視界を塞がない |
| `filter` | `desc` の無いマッピングを除外 | #183 で全マップに `desc` を付与済み。`desc` の有無が「ピッカーで引ける / ポップアップに出る」の単一条件になり一本化される |
| `spec` | `<leader>c` = code, `<leader>f` = find, `<leader>r` = refactor | `<leader>f` に9個ぶら下がっているため、グループ化しないと `<leader>` 直下のリストが縦に伸びる |

**キーマップ**

- `<leader>?` → `require('which-key').show({ global = false })`。カーソル位置のバッファ限定のキーマップを表示する。LSP アタッチ中のファイルなら `gd` / `<leader>rn` / `<leader>ca` などが出る

`plugins.presets` はデフォルト（全て有効）のまま。これにより自作マップだけでなく、`d` / `y` などのオペレータ、モーション、テキストオブジェクト、`<C-w>`、`g` / `z` 系といった **Neovim 本体のバインディング**もポップアップ対象になる。設定ファイルを読んでも分からない領域なので、実質ここが一番効く。

`lazy-lock.json` に `which-key.nvim` を追記（他プラグインのバージョンは変更なし）。

## Impact scope / 影響範囲

`.config/nvim/init.lua` と `.config/nvim/lazy-lock.json` のみ。

- **既存キーマップの挙動は変わらない。** which-key はマッピングを作らず、押された prefix に対してポップアップを出すだけ
- 遅延ロード。`<leader>?` は lazy の `keys` ハンドラ経由で登録され、押された時点で初めて which-key がロードされる。起動時のコストは `VeryLazy` まで発生しない
- ポップアップ表示は 200ms のホールドが条件（which-key のデフォルト）。prefix を続けて打ち切る通常の操作では表示されず、打鍵速度に影響しない

## Testing / 動作確認

- [x] `nvim --headless "+Lazy! sync"` でインストール成功、`lazy-lock.json` が which-key の追加のみで更新されることを確認
- [x] `:checkhealth which-key` が `No issues reported` / `No overlapping keymaps found` / `No duplicate mappings found` を返すことを確認（#183 で `[b` `]b` `[d` `]d` の重複を削除済みのため overlapping / duplicate ゼロ）
- [x] `mini.icons` を検出していることを確認（`nvim-web-devicons is not installed` の WARNING は出るが、which-key はどちらか一方で動作する）
- [x] `<leader>?` が `desc` 付きで lazy の keys ハンドラ経由に登録されていることを `nmap <leader>?` で確認
- [x] 通常起動でエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)