### PR TITLE
fix(settings): disable ctrl+space hotkey via xml plist

### DIFF
--- a/settings.sh
+++ b/settings.sh
@@ -17,12 +17,12 @@ defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool
 defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 
 # Free up Ctrl+Space for tmux prefix by disabling "Select the previous input source"
-# (AppleSymbolicHotKeys id 60). Requires logout/login or `activateSettings -u` to apply.
-# NOTE: On macOS Tahoe (26+) this plist write often fails to propagate to the runtime;
-# if Ctrl+Space still switches input sources, manually uncheck via:
-#   System Settings → Keyboard → Keyboard Shortcuts → Input Sources → "Select the previous input source"
+# (AppleSymbolicHotKeys id 60).
+# Must be XML plist: the old-style `{enabled = 0; ...}` syntax has no number/bool
+# type, so `enabled` lands as the string "0" and macOS falls back to enabled.
 defaults write com.apple.symbolichotkeys.plist AppleSymbolicHotKeys -dict-add 60 \
-  '{enabled = 0; value = { parameters = (32, 49, 262144); type = "standard"; }; }'
+  '<dict><key>enabled</key><false/><key>value</key><dict><key>type</key><string>standard</string><key>parameters</key><array><integer>32</integer><integer>49</integer><integer>262144</integer></array></dict></dict>'
+/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
 
 # Japanese IME (Kotoeri): disable predictive candidates and live conversion.
 # Predictive candidates cause heavily-learned words to be mis-committed during

--- a/settings.sh
+++ b/settings.sh
@@ -22,7 +22,6 @@ defaults -currentHost write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 # type, so `enabled` lands as the string "0" and macOS falls back to enabled.
 defaults write com.apple.symbolichotkeys.plist AppleSymbolicHotKeys -dict-add 60 \
   '<dict><key>enabled</key><false/><key>value</key><dict><key>type</key><string>standard</string><key>parameters</key><array><integer>32</integer><integer>49</integer><integer>262144</integer></array></dict></dict>'
-/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
 
 # Japanese IME (Kotoeri): disable predictive candidates and live conversion.
 # Predictive candidates cause heavily-learned words to be mis-committed during
@@ -31,7 +30,11 @@ defaults write com.apple.symbolichotkeys.plist AppleSymbolicHotKeys -dict-add 60
 defaults write com.apple.inputmethod.Kotoeri JIMPrefPredictiveCandidateKey -bool false
 defaults write com.apple.inputmethod.Kotoeri JIMPrefLiveConversionKey -bool false
 
-echo "macOS settings applied. Please restart your system for all changes to take effect."
+# Symbolic hotkeys are read into the runtime at login, so without this the
+# Ctrl+Space change stays dormant until the next login (and looks like it worked).
+/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+
+echo "macOS settings applied. Ctrl+Space took effect now; the rest (Kotoeri) needs a restart."
 echo ""
 echo -e "\033[1;33m⚠️  RESTART REQUIRED\033[0m"
 echo -e "\033[1;33mSome settings will not take effect until you restart your Mac.\033[0m"

--- a/tests/settings.bats
+++ b/tests/settings.bats
@@ -21,3 +21,15 @@ setup() {
   [ "$status" -eq 0 ]
   [ "$output" = "0" ]
 }
+
+@test "settings.sh disables Ctrl+Space input source switching with a real boolean" {
+  command -v plutil >/dev/null 2>&1 || skip "plutil not available (not macOS)"
+
+  ./settings.sh
+
+  # A string "0" here reads as enabled by macOS, so assert the type too.
+  run plutil -extract AppleSymbolicHotKeys.60.enabled raw -o - \
+    "$HOME/Library/Preferences/com.apple.symbolichotkeys.plist"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}

--- a/tests/settings.bats
+++ b/tests/settings.bats
@@ -32,4 +32,10 @@ setup() {
     "$HOME/Library/Preferences/com.apple.symbolichotkeys.plist"
   [ "$status" -eq 0 ]
   [ "$output" = "false" ]
+
+  # json, not raw: raw prints 32 for both the integer and the string "32".
+  run plutil -extract AppleSymbolicHotKeys.60.value.parameters json -o - \
+    "$HOME/Library/Preferences/com.apple.symbolichotkeys.plist"
+  [ "$status" -eq 0 ]
+  [ "$output" = "[32,49,262144]" ]
 }


### PR DESCRIPTION
## Background / 背景

再起動後に tmux の prefix `Ctrl+Space`（Karabiner の HRM で `d` ホールド = Ctrl）が効かず、代わりに入力ソースが切り替わる（日英変更）症状が発生した。

真因は `settings.sh` の plist 書き込みの型落ちだった。旧形式（NeXTSTEP 形式）の plist リテラル `'{enabled = 0; ...}'` には数値/真偽型が存在しないため、`enabled` は文字列 `"0"`、`parameters` も文字列配列として保存されていた。macOS はこれを「無効」と解釈せず既定（有効）にフォールバックするため、「前の入力ソースを選択」が `Ctrl+Space` に張られたまま OS レベルで消費され、prefix が端末まで届いていなかった。

```
"60" => { "enabled" => "0",  "parameters" => ["32", "49", "262144"] }   ← 壊れたエントリ
"61" => { "enabled" => true, "parameters" => [32, 49, 786432] }         ← システムが書いたエントリ
```

symbolic hotkey の runtime 状態はログイン時に plist から読まれる。壊れたエントリを書いたのは #153 と同日の 2026-07-20 で、次のログインが 2026-07-27 の再起動だったため、そこで初めて症状が露出した（それまではメモリ上の旧状態で動いていた）。

なお削除したコメントの「macOS Tahoe では plist 書き込みが propagate しない」という記述は誤りで、実際は上記の型の問題だった。

## Changes / 変更内容

- `settings.sh`: `AppleSymbolicHotKeys` id 60 の書き込みを XML plist リテラルに変更。`enabled` が本物の boolean、`parameters` が整数として保存される
- `settings.sh`: `activateSettings -u` の実行を追加。ログアウト/再ログインを待たずに runtime へ反映される
- `settings.sh`: 誤っていた Tahoe 由来説のコメントを削除し、「XML plist で書かないと型が落ちる」というガードレールに置き換え（旧形式で書き直すと静かに再発するため）
- `tests/settings.bats`: 回帰テストを追加。`plutil -extract ... raw` で値だけでなく**型**を検証するので、文字列 `"0"` に戻ると落ちる

## Impact scope / 影響範囲

- macOS の「前の入力ソースを選択」（`Ctrl+Space`）が意図通り無効化される。入力ソースの切り替え手段は Karabiner の rule「Tap CMD to toggle Kana/Eisuu」（左 Cmd 単押し = 英数 / 右 Cmd 単押し = かな）が担っており、失われる操作はない
- `Ctrl+Opt+Space`（id 61 = 入力メニューの次のソースを選択）は従来どおり有効。prefix と衝突しないため変更していない
- `settings.sh` に `activateSettings -u` が入ったため、実行時に一部の設定が即時反映されるようになる（従来はスクリプト末尾の再起動案内どおり再起動が必要だった）
- Karabiner / tmux の設定は変更なし

## Testing / 動作確認

- [x] `bats tests/settings.bats` パス（3/3。追加した型検証テストを含む）/ passes
- [x] `shellcheck settings.sh` / `shfmt -i 2 -d settings.sh` クリーン / clean
- [x] 修正適用後、`plutil -p` で `"60" => { "enabled" => false, "parameters" => [32, 49, 262144] }` を確認 / verified stored types
- [x] `activateSettings -u` 実行後、再ログインなしで tmux prefix (`d` + `space`) が復帰することを実機確認 / tmux prefix works again
- [x] 素の ghostty（tmux 非経由）でキーの生バイトを計測し、修正前は Ctrl+Space が端末に届かず（無反応 / 全角スペース `e3 80 80`）、`Ctrl+C` は `03` として届いていたことを確認 / raw byte capture confirmed the OS-level grab

🤖 Generated with [Claude Code](https://claude.com/claude-code)
