### PR TITLE
feat(nvim): route LSP navigation through snacks picker / neovide font

### DIFF
--- a/.config/neovide/config.toml
+++ b/.config/neovide/config.toml
@@ -3,3 +3,9 @@
 
 # Frameless window (no title bar / traffic-light buttons).
 frame = "none"
+
+[font]
+# SF Mono 以降は neovide 内蔵のフォールバックチェーン。SF Mono 単体にすると起動 10〜20 秒後に abort する。
+normal = ["SF Mono", "Menlo", "Monaco", "Courier New", "monospace"]
+# ../zed/settings.json の buffer_font_size と一致させる。ghostty の font-size (13) とは別系統。
+size = 15.0

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -304,10 +304,16 @@ vim.api.nvim_create_autocmd('LspAttach', {
     local function lmap(lhs, rhs, desc)
       map('n', lhs, rhs, { buffer = buf, desc = 'LSP: ' .. desc })
     end
-    -- references / implementation / type definition / document symbol are already
-    -- mapped by Neovim itself (grr / gri / grt / gO) -- see :h lsp-defaults.
+    -- Neovim's own grr / gri / grt / gO (:h lsp-defaults) dump results into the
+    -- quickfix list; these overrides route them through the snacks picker instead.
+    -- Every source auto-confirms on a single result, so the popup only appears
+    -- when there is a real choice to make.
     lmap('K', vim.lsp.buf.hover, 'Hover docs')
-    lmap('gd', vim.lsp.buf.definition, 'Go to definition')
+    lmap('gd', function() Snacks.picker.lsp_definitions() end, 'Go to definition')
+    lmap('grr', function() Snacks.picker.lsp_references() end, 'References')
+    lmap('gri', function() Snacks.picker.lsp_implementations() end, 'Implementations')
+    lmap('grt', function() Snacks.picker.lsp_type_definitions() end, 'Type definitions')
+    lmap('gO', function() Snacks.picker.lsp_symbols() end, 'Document symbols')
     lmap('<leader>rn', vim.lsp.buf.rename, 'Rename symbol')
     lmap('<leader>ca', vim.lsp.buf.code_action, 'Code action')
     lmap('<leader>d', vim.diagnostic.open_float, 'Show diagnostic under cursor')


### PR DESCRIPTION
## Background / 背景

nvim 主力化トライアルの継続。2 点の不満を解消する。

- LSP のナビゲーション（`grr` / `gri` / `grt` / `gO`）は Neovim 標準では結果を quickfix リストに流し込む。すでに他のナビゲーションは snacks.nvim の picker に寄せているため、LSP だけ操作感が分断されていた。
- Neovide はフォント未指定だとデフォルトフォント・デフォルトサイズで起動し、ghostty / Zed と見た目が揃わなかった。

## Changes / 変更内容

### `.config/nvim/init.lua`

- `LspAttach` の keymap で `gd` / `grr` / `gri` / `grt` / `gO` を `Snacks.picker.lsp_*` に差し替え
- いずれも候補が 1 件のときは picker を出さずに自動ジャンプするため、選択肢が実在する場合のみ UI が出る

### `.config/neovide/config.toml`

- `[font]` セクションを追加。`normal` は `SF Mono` に neovide 内蔵のフォールバックチェーン（`Menlo` / `Monaco` / `Courier New` / `monospace`）を明示的に連結
  - SF Mono 単体指定だと起動 10〜20 秒後に abort する事象があったため、フォールバックを必ず並べる
- `size = 15.0` は Zed の `buffer_font_size` と揃える（ghostty の `font-size = 13` とは別系統）

## Impact scope / 影響範囲

- nvim: LSP がアタッチされたバッファのみ。quickfix ベースの挙動に依存した操作はなくなる
- neovide: neovide 起動時の見た目のみ。ghostty 上の nvim には影響しない
- 他のツール設定・link.sh・CI には変更なし

## Testing / 動作確認

- [x] `nvim --headless -c 'quitall'` が エラーなく exit 0
- [x] neovide 起動でフォント・サイズが反映され、10〜20 秒経過後も abort しないことを確認
- [x] `gd` / `grr` / `gri` / `grt` / `gO` が snacks picker 経由で動作し、単一候補では即ジャンプすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)