### PR TITLE
feat(nvim): add git diff signs and lazygit float

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -164,21 +164,11 @@ require('lazy').setup({
     'lewis6991/gitsigns.nvim',
     event = { 'BufReadPre', 'BufNewFile' },
     opts = {
-      signs = {
-        add = { text = '┃' },
-        change = { text = '┃' },
-        delete = { text = '_' },
-        topdelete = { text = '‾' },
-        changedelete = { text = '~' },
-        untracked = { text = '┆' },
-      },
+      -- The defaults already draw a thick bar (┃); only staged is overridden, to
+      -- a thin bar. gitsigns dims staged signs to 50% fg on top of that.
       signs_staged = {
-        add = { text = '┃' },
-        change = { text = '┃' },
-        delete = { text = '_' },
-        topdelete = { text = '‾' },
-        changedelete = { text = '~' },
-        untracked = { text = '┆' },
+        add = { text = '│' },
+        change = { text = '│' },
       },
       on_attach = function(bufnr)
         local gs = require('gitsigns')

--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -107,6 +107,7 @@ require('lazy').setup({
       spec = {
         { '<leader>c', group = 'code' },
         { '<leader>f', group = 'find' },
+        { '<leader>g', group = 'git' },
         { '<leader>r', group = 'refactor' },
       },
     },
@@ -155,6 +156,77 @@ require('lazy').setup({
       view_options = {
         show_hidden = true, -- match telescope find_files (hidden = true)
       },
+    },
+  },
+
+  -- Git signs (gutter bars + inline hunk diff, Zed-like) -------------------
+  {
+    'lewis6991/gitsigns.nvim',
+    event = { 'BufReadPre', 'BufNewFile' },
+    opts = {
+      signs = {
+        add = { text = '┃' },
+        change = { text = '┃' },
+        delete = { text = '_' },
+        topdelete = { text = '‾' },
+        changedelete = { text = '~' },
+        untracked = { text = '┆' },
+      },
+      signs_staged = {
+        add = { text = '┃' },
+        change = { text = '┃' },
+        delete = { text = '_' },
+        topdelete = { text = '‾' },
+        changedelete = { text = '~' },
+        untracked = { text = '┆' },
+      },
+      on_attach = function(bufnr)
+        local gs = require('gitsigns')
+        -- vim.keymap.set, not the `map` local below: that local is declared
+        -- after this chunk, so it is not in scope here.
+        local function gmap(mode, lhs, rhs, desc)
+          vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, desc = 'Git: ' .. desc })
+        end
+
+        gmap('n', ']c', function()
+          -- Keep the built-in ]c / [c when this buffer is in a real diff split
+          if vim.wo.diff then
+            vim.cmd.normal({ ']c', bang = true })
+          else
+            gs.nav_hunk('next')
+          end
+        end, 'Next hunk')
+        gmap('n', '[c', function()
+          if vim.wo.diff then
+            vim.cmd.normal({ '[c', bang = true })
+          else
+            gs.nav_hunk('prev')
+          end
+        end, 'Prev hunk')
+
+        gmap('n', '<leader>gp', gs.preview_hunk, 'Preview hunk (float)')
+        gmap('n', '<leader>gi', gs.preview_hunk_inline, 'Preview hunk (inline)')
+        gmap('n', '<leader>gs', gs.stage_hunk, 'Stage hunk')
+        gmap('n', '<leader>gr', gs.reset_hunk, 'Reset hunk')
+        gmap('v', '<leader>gs', function()
+          gs.stage_hunk({ vim.fn.line('.'), vim.fn.line('v') })
+        end, 'Stage selected lines')
+        gmap('v', '<leader>gr', function()
+          gs.reset_hunk({ vim.fn.line('.'), vim.fn.line('v') })
+        end, 'Reset selected lines')
+        gmap('n', '<leader>gS', gs.stage_buffer, 'Stage buffer')
+        gmap('n', '<leader>gR', gs.reset_buffer, 'Reset buffer')
+        gmap('n', '<leader>gb', function()
+          gs.blame_line({ full = true })
+        end, 'Blame line')
+        gmap('n', '<leader>gB', gs.toggle_current_line_blame, 'Toggle inline blame')
+        gmap('n', '<leader>gw', gs.toggle_word_diff, 'Toggle word diff')
+        gmap('n', '<leader>gd', gs.diffthis, 'Diff against index')
+        gmap('n', '<leader>gD', function()
+          gs.diffthis('~')
+        end, 'Diff against last commit')
+        gmap({ 'o', 'x' }, 'ih', gs.select_hunk, 'Select hunk')
+      end,
     },
   },
 
@@ -220,6 +292,15 @@ map('n', '<leader>fd', function() Snacks.picker.diagnostics() end, { desc = 'Dia
 -- Every map below carries a desc so these two stay useful.
 map('n', '<leader>fk', function() Snacks.picker.keymaps() end, { desc = 'Keymaps (search what is bound)' })
 map('n', '<leader>fc', function() Snacks.picker.commands() end, { desc = 'Ex commands' })
+
+-- Git, repo-wide (the hunk-level maps are buffer-local; see gitsigns above).
+-- git_diff shows staged and unstaged hunks together; <Tab> stages, <C-r> restores.
+map('n', '<leader>gg', function() Snacks.picker.git_diff() end, { desc = 'Git: changed hunks (repo)' })
+map('n', '<leader>gf', function() Snacks.picker.git_status() end, { desc = 'Git: changed files (repo)' })
+-- lazygit in a float. Snacks generates the theme from the colorscheme and sets
+-- os.editPreset=nvim-remote, so `e` opens files in this nvim, not a nested one.
+map('n', '<leader>gG', function() Snacks.lazygit() end, { desc = 'Git: lazygit (float)' })
+map('n', '<leader>gl', function() Snacks.lazygit.log() end, { desc = 'Git: lazygit log' })
 
 -- Projects (Zed cmd+opt+o equivalent)
 map('n', '<leader>fp', '<cmd>NeovimProjectDiscover<CR>', { desc = 'Discover projects' })

--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -1,4 +1,5 @@
 {
+  "gitsigns.nvim": { "branch": "main", "commit": "31d6fb2d618bca1482b9f274751ead5f03461408" },
   "kanagawa.nvim": { "branch": "master", "commit": "bb85e4bfc8d89b0e62c8fa53ccdd13d12e2f77b3" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
   "mini.icons": { "branch": "main", "commit": "98faae31e9be1cc054ae63485e58ceb185efcad0" },

--- a/Brewfile
+++ b/Brewfile
@@ -18,6 +18,7 @@ brew "tree-sitter-cli" # nvim-treesitter (main branch) compiles parsers with thi
 # Development
 brew "gh"
 brew "git-delta"
+brew "lazygit" # launched in a float from nvim (Snacks.lazygit)
 brew "tmux"
 brew "typescript-language-server" # LSP: js/ts (nvim)
 brew "crit"


### PR DESCRIPTION
## Background / 背景

nvim 上で変更差分を視覚的に確認する手段がなかった。Zed の gutter 差分表示に相当する体験を nvim でも得たいのが出発点。加えて、差分を見るだけでなく stage / commit などの git 操作自体も nvim から完結できたほうがよいと判断した。

diff レビュー用 UI として diffview.nvim も試したが不採用とした。既存の snacks.picker が持つ git source と lazygit の組み合わせで用途が足りており、アイコン供給のために mini.icons へ `mock_nvim_web_devicons()` を仕込む必要が生じる副作用も避けたかったため。

## Changes / 変更内容

**gitsigns.nvim を追加**

- gutter に差分バー（`┃`）を表示。staged / unstaged を別サインで区別する
- 行背景は塗らない（`linehl` はデフォルトの off）。gutter バーのみという Zed の見え方に寄せた
- word diff と inline blame は常時 ON だと情報過多になるため off 起点にし、トグルを割り当てた
- hunk 単位の操作（stage / reset / preview / blame / diffthis）と `]c` / `[c` での hunk 移動、`ih` の hunk text object を buffer-local に定義

**snacks.picker の git source をキーマップに追加**

- 新規プラグインは不要。すでに導入済みの snacks が `git_diff` / `git_status` を持っているため、キーマップのみ追加した
- `<leader>gg` はリポジトリ全体の変更 hunk 一覧（staged / unstaged 両方）、`<leader>gf` は変更ファイル一覧

**lazygit の float 起動を追加**

- `Snacks.lazygit()` を利用。snacks 側が colorscheme から lazygit の theme yml を生成し、`os.editPreset = nvim-remote` も注入するため、追加設定なしで kanagawa の配色が反映され、lazygit 内の `e` は nested nvim ではなく親 nvim でファイルを開く
- 本体は Brewfile に追加（安定した CLI なので mise ではなく brew）

**which-key に `<leader>g` = git グループを登録**

キーマップ一覧:

| キー | 動作 |
|---|---|
| `<leader>gg` / `<leader>gf` | 変更 hunk 一覧 / 変更ファイル一覧（リポジトリ全体） |
| `<leader>gG` / `<leader>gl` | lazygit / lazygit log |
| `]c` / `[c` | 次 / 前の hunk |
| `<leader>gp` / `<leader>gi` | hunk preview（float / inline） |
| `<leader>gs` / `<leader>gr` | stage / reset hunk（visual 選択行にも対応） |
| `<leader>gS` / `<leader>gR` | stage / reset buffer |
| `<leader>gb` / `<leader>gB` | blame line / inline blame トグル |
| `<leader>gw` | word diff トグル |
| `<leader>gd` / `<leader>gD` | index との diff / 直前コミットとの diff |
| `ih` | hunk を text object として選択 |

## Impact scope / 影響範囲

- `.config/nvim/init.lua` — プラグイン1つとキーマップの追加のみ。既存行の変更・削除はなし
- `.config/nvim/lazy-lock.json` — gitsigns.nvim の1行追加
- `Brewfile` — lazygit の1行追加
- `]c` / `[c` は built-in（diff 内の差分移動）を上書きするが、`vim.wo.diff` が真のときは built-in にフォールバックするため diff split 内の挙動は変わらない
- 既存の LSP キーマップ（`K` / `gd` / `grr` / `gri` / `grt` / `gO`）とは競合しない。gitsigns 側が使う素キーは `]c` / `[c` / `ih` のみで、残りは `<leader>g` 配下に隔離した

## Testing / 動作確認

- [x] 一時 git リポジトリで hunk 検出とサイン配置を検証。`change @@ -2,1 +2,1 @@` / `add @@ -4 +5,1 @@` を検出し、2行目・5行目にサインが配置された / verified hunk detection and sign placement
- [x] `<leader>gg` が hunk 単位で一覧されることを検証。40行ファイルの3行目と37行目を変更したところ、同一ファイルが pos 1 と pos 34 の2エントリに分かれた / verified hunk-level granularity
- [x] staged 済みの変更も同じ一覧に出ることを確認 / verified staged changes appear in the same list
- [x] lazygit の theme 生成を検証。`~/.cache/nvim/lazygit-theme.yml` に kanagawa の色（`activeBorderColor: #ff9e3b`、`selectedLineBgColor: #223249`）と `os.editPreset: nvim-remote` が出力された / verified generated lazygit theme
- [x] 全モードのキーマップを列挙して衝突・接頭辞重複を検査。本 PR 由来の衝突は 0 件（既存の LSP 上書きと built-in `gc`/`gcc` のみ検出） / verified no keymap collisions
- [x] `bats tests/config.bats tests/brewfile.bats` 11件 pass
- [x] lazygit の float は TUI のため headless 自動検証ができていない。実機での表示確認が必要 / lazygit float not verified headlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
