### PR TITLE
docs(claude): add branch lifecycle conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,16 @@ Use bilingual (English/Japanese) template. Merge with **squash and merge**:
 gh pr merge <PR番号> --squash --delete-branch
 ```
 
+### Branches
+One branch per PR, named `<type>/<short-description>` with the same types as commits (lowercase, hyphens only). Never commit to main directly.
+
+**Merged branches are not kept locally.** `--delete-branch` removes the remote one, which leaves the local branch marked `[gone]` in `git branch -vv` — that marker is the "already merged" signal. Clean them up with `/clean_gone` (deletes `[gone]` branches and their worktrees).
+
+Squash merges rewrite history, so the branch tip is never an ancestor of main and `git branch -d` refuses. Before force-deleting, confirm the PRs really merged instead of reaching for `-D` blindly:
+```bash
+gh pr list --state all --limit 200 --json headRefName,state,number
+```
+
 ### Adding New Dotfiles
 1. Add file to repository
 2. Add entry to `entries` array in `link.sh` (source path only, or `"source:destination"` if target differs)


### PR DESCRIPTION
## Background / 背景

CLAUDE.md にコミットと PR の規約はあったが、ブランチの命名とライフサイクル（いつ消すか）が書かれていなかった。

実際に運用してみると、マージ済みブランチが `[gone]` のままローカルに溜まる。直近では 17 本が残っていた。squash merge を使っているためブランチ tip が main の祖先にならず、`git branch -d` が必ず失敗する。そのまま `-D` に手を伸ばす手順が暗黙知になっていたため、明文化する。

## Changes / 変更内容

Conventions セクションに `### Branches` を追加した。既存の `### Pull Requests`（squash merge + `--delete-branch`）の直後に配置し、ブランチの作成から削除までが一続きに読めるようにした。

記載した内容:

- 1 PR = 1 ブランチ。命名は `<type>/<short-description>` で type はコミットと共通、小文字とハイフンのみ。main への直接コミットはしない
- **マージ済みブランチはローカルにも残さない。** `--delete-branch` でリモートが消えると、ローカルは `git branch -vv` 上で `[gone]` になる。この marker が「マージ済み」の判定材料。掃除は `/clean_gone`（`[gone]` ブランチと関連 worktree を削除）
- squash merge は履歴を書き換えるためブランチ tip が main の祖先にならず `git branch -d` が拒否する。`-D` に手を伸ばす前に `gh pr list --state all --json headRefName,state,number` でマージ実績を確認する

3点目は「`-d` が失敗する → 反射的に `-D`」で未マージの作業を落とさないためのガードレール。

## Impact scope / 影響範囲

- `CLAUDE.md` のみ、10行追加。既存記述の変更・削除はなし
- ドキュメントのみの変更で、スクリプト・設定・シンボリックリンクへの影響はない

## Testing / 動作確認

- [x] `git diff` で追加 10 行のみ・既存行の変更なしを確認 / verified the diff is additive only
- [x] 記載した手順は実際に 17 本の `[gone]` ブランチ削除で使用し、`gh pr list` 照合で全 17 本が MERGED（#167〜#187）であることを確認済み / the documented procedure was exercised on 17 stale branches
- [x] `git branch -d` が squash merge 後に拒否することを実機確認（`test/test-branch` は main の祖先だったため `-d` で削除できた対照ケース） / verified both the refusal and the ancestor case

🤖 Generated with [Claude Code](https://claude.com/claude-code)
