### PR TITLE
docs(cheatsheet): add a Neovim section to the terminal workflow guide

### DIFF
--- a/docs/terminal-workflow.md
+++ b/docs/terminal-workflow.md
@@ -2,192 +2,122 @@
 
 現在導入済みのツールとショートカットで実現できるユースケース一覧。
 
-> キーボード操作（HRM・Ctrl ナビ・tmux prefix）の一次情報源は [`.config/karabiner/HRM.md`](../.config/karabiner/HRM.md)。tmux 内なら `Prefix` → `m` でいつでも表示できる。本ファイルはツール横断の早見表。
+> キー操作の一次情報源は [HRM.md](../.config/karabiner/HRM.md)（`Prefix` → `m`）。
 
 ## Directory Navigation / ディレクトリ移動
 
-| ユースケース | コマンド | ツール |
-|---|---|---|
-| よく行くディレクトリに一発移動 | `z foo` | zoxide |
-| 候補を fzf で選んで移動 | `zi` | zoxide + fzf |
-| 前のディレクトリに戻る | `z-` | zoxide (alias) |
-| 親ディレクトリに移動 | `z..` | zoxide (alias) |
-| hagaspa workspace に移動 | `haga` | alias → `z ~/workspaces/hagaspa` |
-| OLTA workspace に移動 | `olta` | alias → `z ~/workspaces/OLTAInc` |
-| fzf でディレクトリ選んで cd | `Alt+C` | fzf |
+- よく行くディレクトリに一発移動 — `z foo`
+- 候補を fzf で選んで移動 — `zi`
+- 前のディレクトリに戻る — `z-`
+- 親ディレクトリに移動 — `z..`
+- hagaspa workspace に移動 — `haga`
+- OLTA workspace に移動 — `olta`
+- fzf でディレクトリ選んで cd — `Alt+C`
 
 ## File Search / ファイル検索
 
-| ユースケース | コマンド | ツール |
-|---|---|---|
-| カレントディレクトリ配下のファイルを検索してパスを挿入 (bat プレビュー付き) | `Ctrl+T` | fzf + fd + bat |
-| ファイルを選んで bat で全体表示 | `bat` → `Ctrl+T` | fzf + bat |
-| ファイル名で検索 | `fd パターン` | fd |
-| ファイル内容で検索 (grep) | `rg パターン` | ripgrep |
-
-**典型的なファイルを開く流れ:**
-1. `zi` でプロジェクトに移動
-2. `Ctrl+T` でファイルを検索 → `nvim` で開く
-   - 例: `nvim ` → `Ctrl+T` → ファイル選択 → Enter
+- ファイルを検索してパスを挿入 — `Ctrl+T`
+- ファイルを選んで全体表示 — `bat` → `Ctrl+T`
+- ファイル名で検索 — `fd パターン`
+- ファイル内容で検索 — `rg パターン`
+- 検索して nvim で開く — `nvim ` → `Ctrl+T` → Enter
 
 ## Neovim / エディタ
 
-**Leader は `Space`**。プラグインは `.config/nvim/lua/plugins/`、エディタ素のキーマップは `lua/config/keymaps.lua`。
+`Space` → `fk` で引けるのは自分で定義したマップだけ。以下は組み込み。
 
-### 探す
-
-| ユースケース | キー | 備考 |
-|---|---|---|
-| ファイル名で開く | `Space` → `ff` | snacks picker。隠しファイル表示・gitignore 除外 |
-| 内容で grep | `Space` → `fg` | |
-| バッファ切替 | `Space` → `fb` | |
-| プロジェクト切替 | `Space` → `fp` / `fP` | 一覧 / 履歴。`~/workspaces` と `~/worktrees` を走査 |
-| ファイラを開く | `-` または `Space` → `e` | oil。バッファとして編集し保存で反映 |
-| キーマップを検索 | `Space` → `fk` | この config が定義したマップのみ（後述の注意点） |
-| ヘルプを検索 | `Space` → `fh` | 組み込みコマンドを調べる入口 |
-| 押せるキーを見る | `Space` 単独 | which-key。`g` / `z` / `[` / `]` / `Ctrl+W` では組み込みキーの説明も出る |
-
-### 移動・ジャンプ
-
-| ユースケース | キー | 備考 |
-|---|---|---|
-| ジャンプ元に戻る | `Ctrl+O` | jumplist。`gd` で定義に飛んだ後もこれで戻る |
-| ジャンプ先に進む | `Ctrl+I` | `Tab` と同じ |
-| ジャンプリストを表示 | `:jumps` | |
-| 直前の位置に戻る | `''` | バッククォート 2 つなら列も復元 |
-
-### LSP
-
-| ユースケース | キー | 備考 |
-|---|---|---|
-| 定義へ移動 | `gd` | 戻るのは `Ctrl+O` |
-| 参照一覧 | `grr` | 実装は `gri`、型定義は `grt`、シンボルは `gO` |
-| ドキュメント表示 | `K` | |
-| リネーム | `Space` → `rn` | |
-| コードアクション | `Space` → `ca` | |
-| 診断を表示 | `Space` → `d` | 一覧は `Space` → `fd` |
-
-サーバーは brew / mise で入れて PATH から起動（mason 不使用）。定義は `lua/config/lsp.lua`。
-
-### Git
-
-| ユースケース | キー | 備考 |
-|---|---|---|
-| 変更 hunk 一覧（repo 全体） | `Space` → `gg` | staged / unstaged 両方。`Tab` で stage |
-| 変更ファイル一覧 | `Space` → `gf` | untracked もここに出る |
-| lazygit を開く | `Space` → `gG` | float。`e` で親 nvim にファイルが開く |
-| 次 / 前の hunk | `]c` / `[c` | |
-| hunk を stage / 戻す | `Space` → `gs` / `gr` | visual で選択した行だけにも効く |
-| hunk の中身を見る | `Space` → `gi` | その場に inline 展開 |
-| blame | `Space` → `gb` | 行末常時表示のトグルは `Space` → `gB` |
-
-gutter のバーは太い `┃` が unstaged、細い `│` が staged。
-
-> **`Space` → `fk` に出ないキーがある**（ハマりやすい点）: このピッカーの情報源は `nvim_get_keymap` で、**`vim.keymap.set` で定義したマップしか一覧できない**。`Ctrl+O` / `dd` / `gg` / `%` のような Neovim 組み込みコマンドは原理的に出てこない。which-key のポップアップにも出ない（`Ctrl+O` は 1 キーで完結するため、プレフィックス待ちが発生せず表示の機会がない）。組み込みを調べたいときは `Space` → `fh` でヘルプタグを検索するか `:help normal-index` を見る。逆に `Ctrl+D` / `n` / `N` が一覧に出るのは、centering (`zz`) 付きで再マップしているため。
+- ジャンプ元に戻る / 進む — `Ctrl+O` / `Ctrl+I`
+- ジャンプリストを表示 — `:jumps`
+- 直前の位置に戻る — `''`
+- 直前のファイルに戻る — `Ctrl+^`
+- 組み込みコマンドを調べる — `:help normal-index`
 
 ## Tmux / ターミナル多重化
 
-**Prefix: `Ctrl+Space`**（D=Ctrl ホールド + 右親指 Space の bilateral chord。`Ctrl+B` は左手同手チョードで打ちにくいため変更。詳細は [HRM.md](../.config/karabiner/HRM.md)）
+**Prefix: `Ctrl+Space`**
 
-| ユースケース | キー | 備考 |
-|---|---|---|
-| 新しいウィンドウ作成 | `Prefix` → `c` | カレントパスを引き継ぐ |
-| 直前のウィンドウに切替 | `Prefix` → `Space` | |
-| ウィンドウ番号で切替 | `Prefix` → `0-9` | |
-| ペイン移動 (左/下/上/右) | `Prefix` → `h/j/k/l` | vim 風 |
-| yazi をポップアップで開く | `Prefix` → `y` | Helix 連携あり |
-| HRM チートシート表示 | `Prefix` → `m` | HRM.md を bat でポップアップ |
-| セッション一覧 | `Prefix` → `s` | |
-| ウィンドウ一覧 | `Prefix` → `w` | |
-| ペインを水平分割 | `Prefix` → `"` | |
-| ペインを垂直分割 | `Prefix` → `%` | |
-| コピーモード (vi) | `Prefix` → `[` | vi キーバインドで操作 |
-| デタッチ | `Prefix` → `d` | |
+- 新しいウィンドウ作成 — `Prefix` → `c`
+- 直前のウィンドウに切替 — `Prefix` → `Space`
+- ウィンドウ番号で切替 — `Prefix` → `0-9`
+- ペイン移動（左/下/上/右）— `Prefix` → `h/j/k/l`
+- ペインを水平/垂直分割 — `Prefix` → `"` / `%`
+- yazi をポップアップで開く — `Prefix` → `y`
+- HRM チートシート表示 — `Prefix` → `m`
+- 本ファイルを表示 — `Prefix` → `M`
+- セッション一覧 / ウィンドウ一覧 — `Prefix` → `s` / `w`
+- コピーモード（vi）— `Prefix` → `[`
+- デタッチ — `Prefix` → `d`
+- セッション手動保存 / 復元 — `Prefix` → `Ctrl+S` / `Ctrl+R`
 
-**tmux-resurrect / continuum:**
-- セッションは自動保存・自動復元される（`@continuum-restore 'on'`）
-- 手動保存: `Prefix` → `Ctrl+S`
-- 手動復元: `Prefix` → `Ctrl+R`
+セッションは自動保存・自動復元される（tmux-continuum）。
 
 ## Yazi / ファイルマネージャ
 
-tmux 内から `Prefix` → `y` でポップアップ起動。呼び出したペインで nvim が動いていれば、選択したファイルが `:args` で渡される（それ以外は `nvim <paths>` を送る）。
+`Prefix` → `y` で起動。nvim のペインから呼ぶと `:args` で渡る。
 
-| ユースケース | キー | 備考 |
-|---|---|---|
-| プロジェクト保存 | `Ctrl+P` → `s` | |
-| プロジェクト読込 | `Ctrl+P` → `l` | |
-| 前回のプロジェクト | `Ctrl+P` → `p` | |
-| プロジェクト削除 | `Ctrl+P` → `d` | |
-| 隠しファイル表示 | デフォルトで表示 | show_hidden = true |
+- プロジェクト保存 — `Ctrl+P` → `s`
+- プロジェクト読込 — `Ctrl+P` → `l`
+- 前回のプロジェクト — `Ctrl+P` → `p`
+- プロジェクト削除 — `Ctrl+P` → `d`
+
+隠しファイルはデフォルトで表示。
 
 ## History / コマンド履歴
 
-| ユースケース | コマンド | ツール |
-|---|---|---|
-| 履歴をインクリメンタル検索 | `Ctrl+R` | atuin |
-| コマンド入力中に補完候補表示 | (自動) | zsh-autosuggestions |
-| 補完候補を確定 | `→` (右矢印) | zsh-autosuggestions |
+- 履歴をインクリメンタル検索 — `Ctrl+R`
+- 補完候補を確定 — `→`（右矢印）
 
 ## Text / テキスト操作
 
-| ユースケース | コマンド | ツール |
-|---|---|---|
-| ファイル内容を表示 (シンタックスハイライト付き) | `bat ファイル` | bat |
-| ファイル一覧 (カラー + アイコン) | `ls` / `l` | lsd (alias) |
-| 後方へ単語移動 (カーソルを左の単語へ) | `⌥+←` | ghostty `esc:b` → zsh `backward-word`。`Ctrl+,` でも可 (Karabiner) |
-| 前方へ単語移動 (カーソルを右の単語へ) | `⌥+→` | ghostty `esc:f` → zsh `forward-word`。`Ctrl+.` でも可 (Karabiner) |
-| 後方へ単語削除 (カーソル左の単語) | `⌥+Backspace` | zsh: `backward-kill-word` |
-| 前方へ単語削除 (カーソル右の単語) | `⌥+D` | zsh: `kill-word` |
-| 現在のコマンドラインをコピー | `Ctrl+P` → `Ctrl+O` | pbcopy (command.sh) |
-| 画面クリア | `Ctrl+G` | clrscr (command.sh) |
+- ファイル内容を表示 — `bat ファイル`
+- ファイル一覧 — `ls` / `l`
+- 後方 / 前方へ単語移動 — `⌥+←` / `⌥+→`（`Ctrl+,` / `Ctrl+.` でも可）
+- 後方へ単語削除 — `⌥+Backspace`
+- 前方へ単語削除 — `⌥+D`
+- 現在のコマンドラインをコピー — `Ctrl+P` → `Ctrl+O`
+- 画面クリア — `Ctrl+G`
 
-> **`Ctrl+W` は単語削除に使えない**（ハマりやすい点）: Karabiner の Ctrl navigation が `Ctrl+W` → Page Up（`Ctrl+V` → Page Down）に**全アプリで**再マップしているため、シェルに `Ctrl+W` (0x17) は届かない。端末では Page Up = `\e[5~` が zsh で未バインド（`undefined-key`）なので、末尾の `~` だけが残って入力されてしまう。後方単語削除は **`⌥+Backspace`** を使う。`.zshrc` の `WORDCHARS` は `/` を境界に保つよう調整済みで、パスを 1 セグメントずつ消せる（`backward-kill-word` の単語境界に効く）。
+> **`Ctrl+W` は単語削除にならない**（Page Up に再マップ済み・末尾に `~` が残る）。
+> 後方単語削除は `⌥+Backspace`。
 
 ## Keyboard Shortcuts (Karabiner / HRM)
 
-ホームロウmod (HRM) とターミナル向けリマップを Karabiner で定義。**詳細・最新は [HRM.md](../.config/karabiner/HRM.md)（tmux 内なら `Prefix` → `m`）が一次情報源**。設定は `.config/karabiner/karabiner.ts` から `karabiner.json` を生成。以下は要約。
+一次情報源は [HRM.md](../.config/karabiner/HRM.md)（`Prefix` → `m`）。以下は要約。
 
-### Home Row Mods（キーをホールドして修飾キーにする）
+ホールドで修飾キーになるキー:
 
-| キー | ホールド → 修飾 | スコープ |
-|---|---|---|
-| F (左人差し) | Shift | 全アプリ |
-| S (左薬指) | Option | 全アプリ |
-| D (左中指) | Control | 全アプリ |
-| J (右人差し) | Shift | Helix / ターミナル / Chrome を除く |
-| ; (右小指) | Opt + Shift | 全アプリ |
-| Cmd (tap) | 英数 (左) / かな (右) | tap で IME 切替、hold で Cmd |
+- `F`（左人差し）— Shift / 全アプリ
+- `S`（左薬指）— Option / 全アプリ
+- `D`（左中指）— Control / 全アプリ
+- `J`（右人差し）— Shift / ターミナル・Chrome・Zed・Neovide を除く
+- `;`（右小指）— ⌘⌥⌃（Raycast 用）/ 全アプリ
+- `Cmd`（tap）— 英数（左）/ かな（右）、hold で Cmd
 
-- A (左小指) には HRM を載せない（左手首腱鞘炎対策）／Cmd は物理キーのまま
+`A`（左小指）には HRM を載せない（左手首腱鞘炎対策）。Cmd は物理キーのまま。
 
-### Ctrl navigation（D ホールドで Ctrl を作って発火・全アプリ）
+Ctrl navigation（D ホールドで Ctrl を作って発火・全アプリ）:
 
-| キー | 動作 |
-|---|---|
-| `Ctrl+H/J/K/L` | 矢印キー (左/下/上/右) |
-| `Ctrl+,` / `Ctrl+.` | 単語単位で左/右移動 (Option+←/→) |
-| `Ctrl+W` / `Ctrl+V` | Page Up / Page Down |
+- 矢印キー（左/下/上/右）— `Ctrl+H/J/K/L`
+- 単語単位で左/右移動 — `Ctrl+,` / `Ctrl+.`
+- Page Up / Page Down — `Ctrl+W` / `Ctrl+V`
 
-### ターミナル限定
+ターミナル限定:
 
-| キー | 動作 | 備考 |
-|---|---|---|
-| `Ctrl+Space` | 英数 → `Ctrl+Space` | tmux prefix の送出と同時に IME を抜く |
-| `Ctrl` 単押し | 短時間ホールド | 端末向け tap-hold 判定 |
+- tmux prefix の送出と同時に IME を抜く — `Ctrl+Space`
 
 ## Typical Workflows / よくある作業フロー
 
-### 別プロジェクトのファイルを素早く開く
+別プロジェクトのファイルを素早く開く:
+
 ```
 zi          # fzf でプロジェクト選択 → cd
 nvim Ctrl+T # fzf でファイル選択 → Neovim で開く
 ```
 
-### tmux で複数プロジェクトを並行作業
+tmux で複数プロジェクトを並行作業:
+
 ```
 Prefix c           # 新ウィンドウ作成
 zi                 # プロジェクトに移動
-# ウィンドウ番号 (Prefix 0-9) で切替
 Prefix Space       # 直前のウィンドウに素早く戻る
 ```

--- a/docs/terminal-workflow.md
+++ b/docs/terminal-workflow.md
@@ -30,6 +30,61 @@
 2. `Ctrl+T` でファイルを検索 → `nvim` で開く
    - 例: `nvim ` → `Ctrl+T` → ファイル選択 → Enter
 
+## Neovim / エディタ
+
+**Leader は `Space`**。プラグインは `.config/nvim/lua/plugins/`、エディタ素のキーマップは `lua/config/keymaps.lua`。
+
+### 探す
+
+| ユースケース | キー | 備考 |
+|---|---|---|
+| ファイル名で開く | `Space` → `ff` | snacks picker。隠しファイル表示・gitignore 除外 |
+| 内容で grep | `Space` → `fg` | |
+| バッファ切替 | `Space` → `fb` | |
+| プロジェクト切替 | `Space` → `fp` / `fP` | 一覧 / 履歴。`~/workspaces` と `~/worktrees` を走査 |
+| ファイラを開く | `-` または `Space` → `e` | oil。バッファとして編集し保存で反映 |
+| キーマップを検索 | `Space` → `fk` | この config が定義したマップのみ（後述の注意点） |
+| ヘルプを検索 | `Space` → `fh` | 組み込みコマンドを調べる入口 |
+| 押せるキーを見る | `Space` 単独 | which-key。`g` / `z` / `[` / `]` / `Ctrl+W` では組み込みキーの説明も出る |
+
+### 移動・ジャンプ
+
+| ユースケース | キー | 備考 |
+|---|---|---|
+| ジャンプ元に戻る | `Ctrl+O` | jumplist。`gd` で定義に飛んだ後もこれで戻る |
+| ジャンプ先に進む | `Ctrl+I` | `Tab` と同じ |
+| ジャンプリストを表示 | `:jumps` | |
+| 直前の位置に戻る | `''` | バッククォート 2 つなら列も復元 |
+
+### LSP
+
+| ユースケース | キー | 備考 |
+|---|---|---|
+| 定義へ移動 | `gd` | 戻るのは `Ctrl+O` |
+| 参照一覧 | `grr` | 実装は `gri`、型定義は `grt`、シンボルは `gO` |
+| ドキュメント表示 | `K` | |
+| リネーム | `Space` → `rn` | |
+| コードアクション | `Space` → `ca` | |
+| 診断を表示 | `Space` → `d` | 一覧は `Space` → `fd` |
+
+サーバーは brew / mise で入れて PATH から起動（mason 不使用）。定義は `lua/config/lsp.lua`。
+
+### Git
+
+| ユースケース | キー | 備考 |
+|---|---|---|
+| 変更 hunk 一覧（repo 全体） | `Space` → `gg` | staged / unstaged 両方。`Tab` で stage |
+| 変更ファイル一覧 | `Space` → `gf` | untracked もここに出る |
+| lazygit を開く | `Space` → `gG` | float。`e` で親 nvim にファイルが開く |
+| 次 / 前の hunk | `]c` / `[c` | |
+| hunk を stage / 戻す | `Space` → `gs` / `gr` | visual で選択した行だけにも効く |
+| hunk の中身を見る | `Space` → `gi` | その場に inline 展開 |
+| blame | `Space` → `gb` | 行末常時表示のトグルは `Space` → `gB` |
+
+gutter のバーは太い `┃` が unstaged、細い `│` が staged。
+
+> **`Space` → `fk` に出ないキーがある**（ハマりやすい点）: このピッカーの情報源は `nvim_get_keymap` で、**`vim.keymap.set` で定義したマップしか一覧できない**。`Ctrl+O` / `dd` / `gg` / `%` のような Neovim 組み込みコマンドは原理的に出てこない。which-key のポップアップにも出ない（`Ctrl+O` は 1 キーで完結するため、プレフィックス待ちが発生せず表示の機会がない）。組み込みを調べたいときは `Space` → `fh` でヘルプタグを検索するか `:help normal-index` を見る。逆に `Ctrl+D` / `n` / `N` が一覧に出るのは、centering (`zz`) 付きで再マップしているため。
+
 ## Tmux / ターミナル多重化
 
 **Prefix: `Ctrl+Space`**（D=Ctrl ホールド + 右親指 Space の bilateral chord。`Ctrl+B` は左手同手チョードで打ちにくいため変更。詳細は [HRM.md](../.config/karabiner/HRM.md)）
@@ -56,7 +111,7 @@
 
 ## Yazi / ファイルマネージャ
 
-tmux 内から `Prefix` → `y` でポップアップ起動。Helix で開いているときはファイル選択が `:open` に連携される。
+tmux 内から `Prefix` → `y` でポップアップ起動。呼び出したペインで nvim が動いていれば、選択したファイルが `:args` で渡される（それ以外は `nvim <paths>` を送る）。
 
 | ユースケース | キー | 備考 |
 |---|---|---|


### PR DESCRIPTION
## Background / 背景

`<C-o>`（ジャンプ元に戻る）を `<leader>fk`（keymap picker）で探しても見つからず、なぜ出てこないのか分からなくなった。

原因は、**探索手段の対象範囲**だった:

- `Snacks.picker.keymaps()` の情報源は `nvim_get_keymap` / `nvim_buf_get_keymap` で、`vim.keymap.set` で定義したマップしか一覧できない。`<C-o>` は C 実装の組み込みコマンドなのでテーブルに存在しない（実測: 全モード・buffer-local 込みで検索して 0 件、グローバル keymap は 152 件）
- which-key でも出ない。presets は既定で全て有効（実測 288 エントリが `g` / `z` / `[` / `]` / `Ctrl+W` などに登録済み）だが `<C-o>` は含まれず、そもそも which-key はプレフィックス待ちの間に出るものなので、1 キーで完結する `<C-o>` には表示の機会がない
- 一方 `Ctrl+D` / `n` / `N` は一覧に出る。centering (`zz`) 付きで再マップしているため。この非対称が混乱の元だった

which-key の設定変更では構造的に解決しないため、`Prefix` → `m` で開けるチートシートに書く方針にした。

## Changes / 変更内容

`docs/terminal-workflow.md` に `## Neovim / エディタ` セクションを追加した（`## File Search` の直後、ファイルを開く流れの続きになる位置）。

4 つのサブセクションで構成:

- **探す** — picker 系（`ff` / `fg` / `fb` / `fp` / `fh` / `fk`）、oil、`Space` 単独での which-key
- **移動・ジャンプ** — `Ctrl+O` / `Ctrl+I` / `:jumps` / `''`（今回の発端）
- **LSP** — `gd` / `grr` / `K` / `rn` / `ca` / `d`。サーバーが brew・mise 管理で mason 不使用である点も明記
- **Git** — hunk 一覧 / lazygit / `]c` `[c` / stage / inline preview / blame。gutter のバーが太い `┃` = unstaged、細い `│` = staged である点も

最後に、**発見手段の境界**を「ハマりやすい点」の引用ブロックで明記した。既存の `Ctrl+W` が使えない件と同じ書式に合わせている。この 1 段落が今回の学びそのもので、同じ疑問を繰り返さないための記録。

**あわせて Yazi セクションの古い記述を修正した。** 「Helix で開いているときはファイル選択が `:open` に連携される」と書かれていたが、Helix は 2026-07-20 に撤去済みで、実装（`.config/tmux/yazi-picker.sh:13-20`）は呼び出し元ペインが nvim なら `:args` を送り、それ以外は `nvim <paths>` を送る。実装どおりの記述に直した。

## Impact scope / 影響範囲

- ドキュメントのみ。スクリプト・設定・シンボリックリンクへの影響はない
- このファイルは `~/.config/tmux/terminal-workflow.md` にシンボリックリンクされており、tmux の `Prefix` → `m` ポップアップから引ける

## Testing / 動作確認

- [x] **記載した 31 個のキーマップが実在することをプログラムで検証した**（`nvim_get_keymap` + buffer-local を突き合わせ、全件一致）。LSP マップは buffer-local なので yamlls が attach する yaml ファイルを開いて確認 / verified every documented keymap actually exists
- [x] which-key presets が既定で有効・288 エントリ登録済み・`<C-o>` を含まないことを実測（`Config.plugins.presets` と `Config.mappings` を検査）/ verified the presets claim
- [x] Yazi の記述が実装（`yazi-picker.sh`）と一致することを確認 / verified the Yazi behaviour against the script
- [x] symlink 経由（`~/.config/tmux/terminal-workflow.md`）で新セクションが読めることを確認 / verified the symlinked copy resolves
- [x] `bats tests/config.bats` 7 件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
