### PR TITLE
fix(zsh): add mise shims to PATH for GUI-launched apps

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -9,6 +9,9 @@ export LESSCHARSET=utf-8
 # export CLAUDE_CODE_EFFORT_LEVEL=max
 
 # Add user-local binaries to PATH
+# `mise activate` runs in .zshrc, which non-interactive shells skip; GUI apps that
+# spawn `zsh -c` (Neovide) see no mise tools at all without these shims.
+export PATH="$HOME/.local/share/mise/shims:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ cd .config/karabiner && bun run build  # generate → sync repo copy → reload 
 `build` regenerates the config, copies `~/.config/karabiner/karabiner.json` back into the repo (Karabiner's atomic writes break symlinks), and reloads the profile via `karabiner_cli`.
 
 ### Docs
-`docs/` holds decision records and troubleshooting notes (terminal-workflow cheatsheet, cmux-vs-tmux, karabiner-vs-nix, brew-vs-nix, raycast-dotfiles, secure-input-hotkey-outage) and the tooling-roadmap (planned improvements with adopt/reject status). The terminal-workflow cheatsheet is symlinked for the tmux Prefix+M popup.
+`docs/` holds decision records and troubleshooting notes (terminal-workflow cheatsheet, cmux-vs-tmux, karabiner-vs-nix, brew-vs-nix, raycast-dotfiles, secure-input-hotkey-outage, gui-app-path) and the tooling-roadmap (planned improvements with adopt/reject status). The terminal-workflow cheatsheet is symlinked for the tmux Prefix+M popup.
 
 ### Workspace Conventions
 Custom shell functions assume this structure:

--- a/docs/editor-strategy.md
+++ b/docs/editor-strategy.md
@@ -1,87 +1,95 @@
-# エディタ戦略: Zed 主力・nvim は小道具・レビューは crit (2026-07)
+# エディタ戦略: nvim (Neovide) へ主力移行中・Zed 併用・レビューは crit (2026-07)
 
-nvim を主力エディタに育てるか（lazy.nvim + プラグイン群で IDE 化）を検討し、実際に最小スターターを組んで検証した。**結論: nvim を主力にはしない。主力エディタは Zed に確定。nvim は「ターミナル内の即席編集 / 稀な ssh 先編集」用の最小ツール（built-ins only）に留める。PR レビュー / AI 成果物レビューは crit を層として残し、Zed を編集・閲覧のサーフェスとして合成する。**
+2026-07 前半に「主力は Zed、nvim は built-ins only の小道具」と一度結論したが、**2026-07-22 に本人判断で nvim 主力化を再トライアル**し、現在も継続中。**現状: 日常の編集を nvim (Neovide) に寄せる移行期間で、Zed は併用。PR / AI 成果物レビューは crit を層として残す（当初判断から不変）。** トライアルの成否判定軸は設けていない（期限や judge 基準を決めずに訓練期間として続ける）。
 
-## 背景（判断を規定した制約）
+## 現在地 (2026-07-27)
 
-作業スタイルが editor 選定を強く規定している。
+| 項目 | 状態 |
+|---|---|
+| GUI フロントエンド | **Neovide**（#175）。`frame = "none"`、フォントは SF Mono 15pt（→ [.config/neovide/config.toml](../.config/neovide/config.toml)） |
+| プラグイン管理 | lazy.nvim。`lazy-lock.json` 11 エントリ（lazy.nvim 自身を含む） |
+| 構成 | `init.lua` は bootstrap のみ。`lua/config/`（options / keymaps / autocmds / lsp）+ `lua/plugins/`（git / editor / picker / treesitter / ui）に分割（#189） |
+| LSP | nvim-native `vim.lsp.config` + `vim.lsp.enable`。yamlls / rust_analyzer / ts_ls。**mason 不使用の PATH ベース運用** |
+| picker | snacks.nvim（telescope から置換, #182）。LSP のジャンプ系も snacks に集約（#186） |
+| git | gitsigns + snacks.picker (git_diff / git_status) + lazygit フロート（#187） |
+| その他 | oil.nvim（#179）、which-key（#184）、neovim-project + session-manager、treesitter、kanagawa (wave) |
 
-- **打鍵最速・トラックパッド一切不使用**。これを満たせる GUI エディタは実質 Zed のみ（VS Code / Cursor はこの理由で不採用）
-- **MacBook 15" 単一画面のみ・外部ディスプレイ不使用**。全アプリを maximize し、Raycast でアプリを切り替える。画面に余計な情報を出したくない
-- 上記から **Claude Code をエディタに組み込まない**。画面が狭くなるため。Claude Code は ghostty かネイティブアプリで動かす
-- **k8s クラスタにほぼログインしない**（GKE マネージド・GitOps デプロイ・本番ログイン回避）。クラスタ内に入るのは趣味の bons8i（kubeadm）で稀にある程度
-- 最近は**コードを書くより PR レビュー・Notion 資料作成が中心**。crit を多用
-- 業務コードは **SQL・dbt などデータ基盤**がほとんど（重量級 IDE 機能の需要が薄い）
-- ディレクトリ移動は ghostty、git 操作も以前は ghostty だが最近は **Claude Code skill** に寄っている
+派生して解決した問題: GUI から起動した Neovide は `.zshrc` を読まず mise 管理ツールが PATH から消える（rust-analyzer が起動しない）。`.zshenv` に mise shims を追加して解消 → [gui-app-path.md](gui-app-path.md)。
 
-## 検討した問い
+## 当初の判断（2026-07 前半）とその根拠
 
-1. 中長期の操作速度で見て、nvim に寄せる方がレバレッジが効くか
-2. AI にコードを書かせる時代、「エディタ＝ビューワー」化する中でどちらが合理的か
-3. 直近、シニア以上のエンジニアは nvim を使う側が多いのか
+以下は再トライアル前の分析。**前提の多くは今も有効**なので、判断の土台として残す。
 
-## 調査結果（2025〜2026）
+### 背景（判断を規定した制約）
+
+- **打鍵最速・トラックパッド一切不使用**（VS Code / Cursor はこの理由で不採用）
+- **MacBook 15" 単一画面のみ・外部ディスプレイ不使用**。全アプリを maximize し、Raycast で切り替える
+- 上記から **Claude Code をエディタに組み込まない**。Claude Code は ghostty かネイティブアプリで動かす
+- **k8s クラスタにほぼログインしない**（GKE マネージド・GitOps・本番ログイン回避）
+- **PR レビュー・Notion 資料作成が中心**で crit を多用。業務コードは **SQL・dbt** がほとんど
+- ディレクトリ移動は ghostty、git 操作は Claude Code skill に寄っている
+
+### 調査結果（2025〜2026）
 
 | 指標 | 数値 | 出典 |
 |---|---|---|
 | エディタシェア (SO Survey 2025) | VS Code ~76% / Vim ~24% / **Neovim ~12–14%** / **Zed 7.3%** / Cursor 18% / Claude Code ~10% | Stack Overflow Developer Survey 2025 |
 | Neovim の満足度 | **most admired** エディタ（2024: 83%、2025 も1位）。継続利用意向 81%（VS Code 77%） | 同上 / programming.dev |
-| Zed の到達点 | 2026-04 に **Zed 1.0**、デイリーユーザー数十万規模。ACP で Claude Code / Codex / Gemini CLI をネイティブ統合、並列エージェント対応 | zed.dev |
+| Zed の到達点 | 2026-04 に **Zed 1.0**。ACP で Claude Code / Codex / Gemini CLI をネイティブ統合、並列エージェント対応 | zed.dev |
 
-- Neovim は「**使う人の満足度・定着率が突出して高いニッチ**」。熟練層に偏る傾向はあるが、絶対数ではシニアでも VS Code が最多で、「直近シニアが続々 nvim へ移行」という事実はない。直近の主流トレンドは AI ネイティブエディタ（Cursor / Claude Code / Zed）の台頭
-- Zed 自身の nvim 比較でも、nvim の優位を「**ターミナルネイティブ（SSH・コンテナ・リモートで動く）**」「Lua の拡張性」と認め、Zed の優位を「設定不要で即戦力」「AI・LSP・協調編集が**組み込み**」としている
+Neovim は「使う人の満足度・定着率が突出して高いニッチ」。ただし「直近シニアが続々 nvim へ移行」という事実はない。Zed 自身の比較でも nvim の優位は「ターミナルネイティブ（SSH・コンテナ・リモート）」「Lua の拡張性」とされる。
 
-## 制約の当てはめ（決め手）
+### 当時の結論
 
-一般論では「Platform Engineer ＝ リモート/ターミナル ubiquity が効くので nvim にも地位が残る」と考えられる。しかし**本人の実運用**を当てると崩れる。
+「クラスタにほぼ入らない → **nvim 最大の固有レバレッジ（リモート/ターミナル ubiquity）が無効化**」を分岐点として、Zed を主力に確定し、nvim は built-ins only に留めると決めた。同時に、lazy.nvim + telescope + mason で組んだ IDE 構成を一度全破棄している。
 
-| 前提 | 効き方 |
+## 再トライアルで変わったこと・変わっていないこと
+
+| 当初の前提 | 現在 |
 |---|---|
-| トラックパッド不使用の GUI は Zed だけ | **Zed 確定**の直接理由 |
-| 単一画面・maximize・Raycast 切替・Claude Code 非組み込み | Zed の **ACP/組み込みエージェント**の強みは**使わない**前提 → 選定理由にならない |
-| クラスタにほぼ入らない | **nvim 最大の固有レバレッジ（リモート/ターミナル ubiquity）がほぼ無効化** ← 判断の分岐点 |
-| レビュー・資料作成中心、crit 多用 | 読む/レビューの GUI 品質が効く（Zed 寄り） |
-| SQL・dbt 中心 | 重量級 IDE 機能不要。nvim を作り込む旨味が薄い |
-| 移動は ghostty、git は Claude Code skill | ターミナル側は ghostty + Claude Code で完結。nvim の常用面がない |
-
-日常は「**ghostty（移動＋Claude Code）↔ Zed（編集・閲覧・レビュー）↔ ブラウザ/Notion**」を Raycast で切り替える構成。この中で nvim が担う固有の仕事はほぼ残らない。
+| トラックパッド不使用の GUI は Zed だけ | ❌ **崩れた**。Neovide の採用で GUI 版 nvim が選択肢に入った（これが再トライアルを可能にした実質的な変化） |
+| nvim には常用面がない | ❌ **崩れた**。日常編集を nvim に寄せる運用に変えた（本人の意思による転換で、外部条件の変化ではない） |
+| クラスタにほぼ入らない | ⭕ 不変。ubiquity は依然として決め手にならない（＝ nvim を選ぶ理由は ubiquity ではなく打鍵体験と拡張性） |
+| SQL / dbt 中心・重量級 IDE 機能は不要 | ⭕ 不変 |
+| Claude Code をエディタに組み込まない | ⭕ 不変。ghostty / ネイティブで動かす |
+| レビューは crit が必要 | ⭕ 不変（次節） |
 
 ## レビュー体験の事実確認（期待と現実のズレ）
 
-「crit でやってることを Zed でやる」を Zed 単体で満たせるかを確認した。**結論: 近い将来は不可。crit は手放さない。**
+「crit でやってることをエディタ単体で満たせるか」の確認結果。**結論: 不可。crit は手放さない。** これは Zed 主力を前提にした確認だが、nvim 主力化後も結論は変わらない（nvim にも PR コメントスレッド層はない）。
 
-- **ローカルの git 差分レビューは Zed が得意**（ファイル単位 diff タブ、ハンク単位 stage/restore、diff 統計、multibuffer）。Claude Code が書いた未コミット変更を Zed で差分レビューするのは快適
-- **GitHub の PR レビュー（PR ファイル閲覧・コメントスレッド・viewed マーク）は Zed にまだ無い**（2026 時点で要望多数・未実装。`git: create pull request` が入った程度）
-- **AI 変更のハンク accept/reject は crit の代替ではない**。あれは「AI の編集を取り込むか捨てるか」の**承認ゲート**であって、コメント/批評を残す crit とは目的が違う。しかも **Zed 内でエージェントを動かしているときだけ**現れる UI で、ghostty/ネイティブで Claude Code を動かす本運用では**そもそも表示されない**（Zed 側は通常の git 差分として見えるだけ）
+- **ローカルの git 差分レビュー**は Zed が得意（ファイル単位 diff タブ、ハンク単位 stage/restore、multibuffer）。nvim 側は gitsigns + snacks.picker + lazygit で代替する構成にした（#187）
+- **GitHub の PR レビュー（コメントスレッド・viewed マーク）は Zed にまだ無い**（2026 時点で要望多数・未実装）
+- **AI 変更のハンク accept/reject は crit の代替ではない**。あれは承認ゲートであり、批評を残す crit とは目的が違う。しかも Zed 内でエージェントを動かしているときだけ現れる UI で、ghostty で Claude Code を動かす本運用では表示されない
 
-→ Zed = 差分の**閲覧・編集サーフェス**、crit = **レビューコメント層**（エディタ非依存・GitHub PR 同期）。両者は競合ではなく**合成**する。
+→ エディタ = 差分の**閲覧・編集サーフェス**、crit = **レビューコメント層**（エディタ非依存・GitHub PR 同期）。両者は競合ではなく**合成**する。
 
-## 意思決定
+## 維持している判断
 
-1. **主力エディタは Zed に確定**。全制約（no-trackpad GUI・単一画面・レビュー中心・SQL/dbt）に最も噛み合い、設定保守コストがゼロ
-2. **nvim は主力候補から降格**し、**bons8i の ssh 編集 / ghostty 内の即席編集用の最小ツール**に位置づける。**built-ins only（プラグインマネージャなし）を維持し、これ以上プラグインを足して育てない**（常用面がない以上、保守税を回収できない）
-3. **レビューは crit + Zed の合成**で運用。Zed のネイティブ PR レビューは当面期待しない
-4. **muscle memory は Zed の Vim mode で共有**し、no-trackpad の打鍵資産を二重投資にしない
+1. **Claude Code をエディタに組み込まない**（単一画面・maximize 運用のため）
+2. **レビューは crit + エディタの合成**。エディタのネイティブ PR レビューを当てにしない
+3. **LSP は PATH ベース（brew / mise）で mason を使わない**。理由と設計境界は [gui-app-path.md](gui-app-path.md)
+4. **LazyVim へは移行しない**。mason 前提の LSP スタックが PATH ベース運用と衝突し、core だけでプラグインが 11 → 28 に増える（→ [tooling-roadmap.md](tooling-roadmap.md)）
+5. **Zed は消さない**。移行期間中の併用先として残す
 
-## nvim をどう残すか（今回の実装判断）
+## 引き受けたコスト
 
-このセッションで一度 lazy.nvim + telescope + neovim-project + treesitter + mason で IDE 化を試したが、**上記の意思決定に伴い全て破棄し、元の built-ins-only の `init.lua` に戻した**。
-
-破棄の副次的な裏付けとして、nvim 0.12.4（本環境）では **固定タグ/旧ブランチがことごとく非互換**だった（nvim-treesitter master、telescope 0.1.8、加えて main ブランチは tree-sitter CLI 依存）。1 セッションで版非互換を 3 件踏んだ事実は、「常用面のないツールにプラグイン保守税を払う」ことの割に合わなさを裏付けている。最小構成（native LSP + 組み込み補完 + `:find`/`netrw`）は ssh/即席編集の役割に必要十分。
+nvim 主力化は、当初「常用面がないので割に合わない」と判断した**プラグイン保守税を引き受ける**という選択でもある。実際 2026-07 の一度目の構築では、nvim 0.12.4 に対して固定タグ / 旧ブランチの非互換を 1 セッションで 3 件踏んだ（nvim-treesitter master、telescope 0.1.8、main ブランチの tree-sitter CLI 依存）。常用面ができた以上この税は回収可能な見込みだが、**プラグインを増やすほど戻りにくくなる**点は意識して、追加は「最小構成 + 明確に便利なもの」に絞る。
 
 ## 再検討のトリガー
 
-1. クラスタ/コンテナ/リモートに**日常的に入る**運用に変わった（nvim の ubiquity が効き始める）
-2. Zed が **GitHub PR レビュー（コメントスレッド）をネイティブ実装**した（crit との合成を見直す契機）
-3. Zed が no-trackpad 運用や単一画面ワークフローを破壊する変更を入れた（GUI 主力の前提が崩れる）
-4. コードを書く比率が大きく戻り、SQL/dbt を超える重量級言語が主戦場になった
+1. **保守税が回収できないと感じ始めた**（nvim 更新のたびに壊れて作業が止まる頻度が上がった）→ プラグイン削減か Zed 復帰を検討
+2. Zed が **GitHub PR レビューをネイティブ実装**した（crit との合成を見直す契機。nvim 主力化とは独立の論点）
+3. Neovide が no-trackpad 運用や単一画面ワークフローを破壊する変更を入れた
+4. クラスタ / コンテナに**日常的に入る**運用に変わった（nvim の ubiquity が効き始め、判断がさらに補強される）
+5. コードを書く比率が大きく戻り、SQL/dbt を超える重量級言語が主戦場になった
 
 ## 参考リンク
 
+- [Neovide](https://neovide.dev/) / [Neovide FAQ: macOS Login Shells](https://neovide.dev/faq.html)
 - [Stack Overflow Dev Survey: VS Code Holds Off AI IDEs (Visual Studio Magazine)](https://visualstudiomagazine.com/articles/2025/08/01/stack-overflow-dev-survey-visual-studio-vs-code-hold-of-ai-ides-to-remain-on-top.aspx)
 - [Neovim is highly Admired — Stack Overflow Developer Survey](https://programming.dev/post/85088)
 - [Zed vs. Neovim: An Honest Comparison for 2026 (zed.dev)](https://zed.dev/compare/neovim)
 - [Zed — Git integration docs](https://zed.dev/docs/git)
 - [GitHub integration for reviewing PRs directly inside Zed — Discussion #34759](https://github.com/zed-industries/zed/discussions/34759)
 - [Support for PR reviews inside the editor — Discussion #40786](https://github.com/zed-industries/zed/discussions/40786)
-- [Zed — The AI Code Editor Built for Speed (Terminal Threads / Parallel Agents)](https://zed.dev/ai)

--- a/docs/gui-app-path.md
+++ b/docs/gui-app-path.md
@@ -1,0 +1,93 @@
+# GUI アプリ起動時の PATH 欠落と mise shims (2026-07)
+
+Neovide で `.rs` を開いても rust-analyzer が起動しない事象を調べた結果、**GUI から起動したアプリが `.zshrc` を読まないため mise 管理のツールが PATH から消えていた**ことが原因だった。**対応: `.zshenv` に mise の shims ディレクトリを追加した。nvim 側（mason 等）には寄せない。**
+
+## 症状と切り分け
+
+Neovide 内の nvim で `rust_analyzer` の LSP クライアントが 0 件。一方で `ts_ls` / `yamlls` は動いていた。
+
+Neovide が起動している nvim の実プロセス:
+
+```
+/usr/bin/login -fpq haga /bin/zsh -c exec nvim --embed -p
+```
+
+`login` を挟むのは Neovide が意図的にやっていること（[FAQ の "macOS Login Shells"](https://neovide.dev/faq.html) — GUI ログインは `.zprofile` を実行しないため）。ただし `zsh -c` は**非対話**なので、そこから先の `.zshrc` は読まれない。本リポジトリでは `mise activate zsh` が `.zshrc` にしかないため、mise 管理ツールのパスが一切生えない。
+
+`ps eww` で見た当時の nvim の PATH（mise 系ゼロ）:
+
+```
+/opt/homebrew/bin, /usr/local/bin, /usr/bin, /bin, ... , ~/.cargo/bin, ~/.local/bin
+```
+
+| 起動経路 | シェル | `.zprofile` | `.zshrc` | mise パス |
+|---|---|---|---|---|
+| ghostty の nvim | 対話 | ✅ | ✅ | ✅ |
+| Zed | 起動時に対話ログインシェルで env を捕捉 | ✅ | ✅ | ✅ |
+| Neovide（Dock / Raycast） | `login` + `zsh -c`（非対話） | ✅ | ❌ | ❌ |
+
+分岐点は「brew か mise か」ではなく「**PATH の生え方が `.zshrc` に依存しているか**」。brew のサーバーは `/opt/homebrew/bin` に実体があり `.zprofile` の `brew shellenv` で解決できるので無事だった。Zed は起動時に対話ログインシェルを走らせて環境変数を取り込む実装を持つため影響を受けない（実測: Zed が起動した rust-analyzer は mise の `installs/` から起動していた）。
+
+## 対応
+
+`.zshenv`（非対話でも読まれる）に shims を追加する。
+
+```sh
+export PATH="$HOME/.local/share/mise/shims:$PATH"
+```
+
+- mise の公式ドキュメントも [IDE やスクリプトなど非対話環境では shims を使う](https://mise.jdx.dev/dev-tools/shims.html)ことを推奨している（対話シェルは `mise activate` 推奨）
+- 対話シェルでは後から `.zshrc` の `mise activate` が `installs/` を PATH 先頭に置くため、shims は事実上使われない。ghostty / Zed の解決先は変更前と同じ（検証済み）
+- `~/.cargo/bin`（rustup）より後ろに置いてあるので、`cargo` / `rustc` の解決先も従来どおり変わらない
+- shims は**実行時のカレントディレクトリで版を解決する**ので、プロジェクトごとのバージョン固定は保たれる
+
+shims の既知の制約は「`mise.toml` の `[env]` が mise 管理ツールにしか渡らない」「`cd` / `enter` / `leave` フックが効かない」「`which` が shim のパスを返す」の 3 点。`.mise.toml` は `[settings]` と `[tools]` だけで `[env]` もフックも使っていないため、実害はない。
+
+## なぜ nvim 側（mason）に寄せないか
+
+「nvim で使うものは nvim の中で完結させたほうがいいのでは」という設計案は検討した上で不採用。
+
+- **mason では塞ぎきれない**: mason は自前の bin を `vim.env.PATH` に前置するので LSP バイナリは動くようになるが、mason が入れる node 系サーバー（ts_ls / yaml-language-server / eslint 等）は実行に `node` を要求し、その `node` は mise 管理なので PATH が壊れたままでは動かない。formatter、`tree-sitter` CLI、`:!` で叩く外部コマンドも同じ穴に落ちる。**PATH を直せば mason は要らず、直さなければ mason でも足りない**
+- **mise の主要価値を失う**: mason はグローバル 1 バージョンで、プロジェクトごとの版固定ができない
+- **パッケージマネージャが 3 つになる**: brew first / 必要なものだけ mise、という本リポジトリの方針（CLAUDE.md）と衝突する。LazyVim を見送った理由（→ [editor-strategy.md](editor-strategy.md)）とも同じ
+
+採用した設計境界は次のとおり:
+
+> 実行ファイルの供給はシェル層（brew / mise）の責務。nvim は PATH を消費するだけ。GUI 起動時の env 欠落は入口（`.zshenv`）で一度だけ直す。
+
+nvim 側（`init.lua` で `vim.env.PATH` に前置）で塞ぐ案もあるが、Neovide からしか使わないツールは存在しないため二重管理になるだけと判断した。
+
+## 検証手順
+
+Neovide の環境を再現して LSP の attach を確認する。
+
+```sh
+SIM=$(env -i HOME=$HOME TERM=xterm /bin/zsh -l -c 'echo $PATH')   # login + 非対話 = Neovide 相当
+cd ~/workspaces/hagaspa/csvtool
+env -i HOME=$HOME TERM=xterm PATH="$SIM" nvim --headless src/main.rs \
+  -c 'sleep 8' \
+  -c 'lua print(#vim.lsp.get_clients({bufnr=0}), vim.fn.exepath("rust-analyzer"))' -c 'qa'
+```
+
+修正前は `0`（`exepath` が空）、修正後は `1 /Users/<user>/.local/share/mise/shims/rust-analyzer`。
+
+起動中の GUI アプリの実効 PATH を直接見る場合:
+
+```sh
+pgrep -fl "nvim --embed"        # Neovide 配下の nvim を特定
+ps eww -p <pid> | tr ' ' '\n' | grep '^PATH='
+```
+
+なお、ターミナルから `neovide` と打って起動した場合は親シェルの環境を継承するのでこの症状は出ない。**Dock / Raycast 起動でのみ再現する**点が切り分けを紛らわしくする。
+
+## 再検討のトリガー
+
+1. `.mise.toml` に `[env]` やディレクトリフックを使い始めた（shims の制約が実害になる。`.zshenv` 側で `mise activate` を呼ぶ構成への変更を検討する）
+2. Neovide が対話シェル経由の env 取り込みを実装した（shims 追加が不要になる可能性）
+3. mise 管理ツールを新規追加したのに GUI から見えない（`mise reshim` が要るケース。shim の有無を `ls ~/.local/share/mise/shims` で確認する）
+
+## 参考リンク
+
+- [mise: Shims](https://mise.jdx.dev/dev-tools/shims.html) — 非対話環境では shims、対話シェルでは activate
+- [Neovide FAQ: macOS Login Shells](https://neovide.dev/faq.html) — GUI ログインが `.zprofile` を実行しない件
+- [editor-strategy.md](editor-strategy.md) — nvim / Zed の役割分担と LazyVim 見送りの判断


### PR DESCRIPTION
## Background / 背景

Neovide で `.rs` を開いても rust-analyzer が起動しない事象を調査した。原因は nvim 設定ではなく **PATH**。

Neovide は nvim を `/usr/bin/login -fpq haga /bin/zsh -c exec nvim --embed` で起動する（[FAQ の "macOS Login Shells"](https://neovide.dev/faq.html) のとおり login を挟む）。`zsh -c` は非対話なので `.zshrc` が読まれず、そこにしかない `mise activate zsh` が走らない。結果、mise 管理の rust-analyzer が PATH から消えていた。brew の `ts_ls` / `yamlls` は `/opt/homebrew/bin` に実体があり `.zprofile` の `brew shellenv` で解決できるため無事だった。Zed は起動時に対話ログインシェルで env を捕捉する実装のため影響を受けていない（実測で確認）。

あわせて、`docs/editor-strategy.md` の内容が 2026-07-22 に始めた nvim 主力化トライアル以前の状態（「Zed 主力・nvim は built-ins only の小道具」）のままだったため、現状に合わせて更新した。

## Changes / 変更内容

- `.zshenv`: mise の shims ディレクトリを PATH に追加（非対話シェルでも読まれるため GUI 起動アプリ全般に効く）
- `docs/gui-app-path.md`（新規）: 切り分け・起動経路ごとの比較・採用した設計境界（実行ファイルの供給はシェル層の責務、nvim は PATH を消費するだけ）・mason に寄せない理由・再現検証手順
- `docs/editor-strategy.md`: 「nvim (Neovide) へ主力移行中・Zed 併用」に更新。当初判断の分析は土台として残しつつ、前提の棚卸し・維持している判断・引き受けたコスト（プラグイン保守税）・再検討トリガーを現状に合わせて再構成
- `CLAUDE.md`: docs 一覧に `gui-app-path` を追加

## Impact scope / 影響範囲

- 影響するのは PATH のみ。shims は `~/.cargo/bin` より後ろに置いたため `cargo` / `rustc` の解決先は変わらない
- 対話シェルでは従来どおり `.zshrc` の `mise activate` が `installs/` を PATH 先頭に置くため、ghostty / Zed の解決先も不変
- shims の既知の制約（`mise.toml` の `[env]` が mise ツールにしか渡らない / `cd` フック無効 / `which` が shim を返す）は、`.mise.toml` が `[settings]` と `[tools]` のみのため実害なし
- Neovide は再起動が必要（env は nvim spawn 時に確定するため）

## Testing / 動作確認

- [x] Neovide 相当の環境（`login` + 非対話 zsh の PATH）を再現した headless nvim で `rust_analyzer` の attach を確認（修正前 0 件 → 修正後 1 件、`exepath` が shims を返す）
- [x] 回帰確認: 対話ログインシェルでの解決先が不変（`rust-analyzer` → `installs/`、`node` → `installs/`、`cargo` → `~/.cargo/bin`）
- [x] `zsh -n .zshenv` 構文チェック
- [x] `bats tests/config.bats tests/link.bats` 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)