### PR TITLE
feat(zed): hide tab bar

### DIFF
--- a/.config/zed/settings.json
+++ b/.config/zed/settings.json
@@ -14,6 +14,9 @@
   },
   "vim_mode": true,
   "relative_line_numbers": "enabled",
+  "tab_bar": {
+    "show": false
+  },
   "icon_theme": {
     "mode": "dark",
     "light": "Zed (Default)",


### PR DESCRIPTION
## Background / 背景

Neovide 脱却（#192）に伴い、当面の開発を Zed（vim モード）中心に戻す。Zed の vim モードは `ctrl-o`/`ctrl-^`/`gd`/`grr` など nvim と共通の操作をデフォルトで備えており、nvim に近い「バッファは見えず、ジャンプ系キーとファインダーで移動する」使い方に寄せるため、タブバーを非表示にする。

なお kanagawa テーマへの変更・SF Mono 化・周辺 UI の色統一も試したが、見た目の改善が小さく既存の Ayu Mirage の方が好みだったため採用しない（この PR には含まれない）。

## Changes / 変更内容

- `.config/zed/settings.json`: `tab_bar.show: false` を追加

## Impact scope / 影響範囲

- Zed のタブバーが非表示になる。開いたファイルはバッファとして残り、`ctrl-^`（直前バッファ）・`ctrl-o`/`ctrl-i`（ジャンプリスト）・`cmd-p`（ファインダー）・`opt-[` / `opt-]`（keymap.json の既存タブ巡回）で移動する
- Zed 以外への影響なし

## Testing / 動作確認

- [x] settings.json が JSON として妥当（コメント除去後にパース確認）
- [x] Zed 実機でタブバーが消え、バッファ移動系キーが機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)