### PR TITLE
feat(zsh): reuse existing zed window on cli open

### DIFF
--- a/.config/zsh/alias.sh
+++ b/.config/zsh/alias.sh
@@ -9,6 +9,10 @@ alias olta="z ~/workspaces/OLTAInc"
 
 alias c="claude"
 
+# -r は --help に出ない隠しフラグ。既存ウィンドウの workspace を差し替える
+alias zed='zed -r'
+alias zed.='zed .'
+
 # git aliases
 alias ga='git add'
 alias ga.='git add .'


### PR DESCRIPTION
## Background / 背景

ターミナルから `zed .` を実行すると毎回新しいウィンドウが開いてしまい、既存の Zed ウィンドウが使われなかった。既存ウィンドウのプロジェクトを差し替える（swap する）挙動が欲しかった。

`cli_default_open_behavior` 設定では実現できない。この設定の値は `existing_window`（サイドバーへ追加）と `new_window`（新規ウィンドウ）の 2 つだけで、swap に相当する値が存在しないため。swap は CLI の `-r` / `--reuse` フラグ側にあり、`hide = true` 指定のため `zed --help` には表示されない。

## Changes / 変更内容

`.config/zsh/alias.sh` にエイリアスを 2 つ追加した。

- `alias zed='zed -r'` — CLI から開くときに既存ウィンドウの workspace を差し替える
- `alias zed.='zed .'` — 実際に使うのは `zed .` だけなので短縮形を用意した

`-r` は `zed` 側のみに書いている。zsh は alias 展開結果の先頭ワードを再度 alias として展開するため、`zed.` → `zed .` → `zed -r .` となりフラグの記述が 1 箇所で済む。

`-r` は `zed --help` に出ない隠しフラグで、由来が分からないと削除されやすいためコメントを 1 行だけ残した。

## Impact scope / 影響範囲

- 影響するのは zsh のインタラクティブシェルから `zed` を実行した場合のみ
- `zed -n .` は後勝ちで新規ウィンドウが開く。`\zed` でエイリアス自体を迂回できる
- Finder のダブルクリック等、CLI 以外の経路は `cli_default_open_behavior` のままで変更なし
- `-r` は引数がディレクトリでもファイルでも swap するため、`zed <file>` はウィンドウのプロジェクトをファイル 1 枚の workspace に置き換える

## Testing / 動作確認

- [x] `zed .` で既存ウィンドウが差し替わることを確認
- [x] `zed.` が `zed -r .` に展開されることを確認（`zsh -c "alias zed='echo RAN -r'; alias zed.='zed .'; eval 'zed.'"` → `RAN -r .`）
- [x] `zed -r --version` が正常終了し、Zed 1.13.1 でフラグが受理されることを確認
- [x] `zsh -n .config/zsh/alias.sh` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)