### PR TITLE
feat(vimium): add Vimium C config with ctrl-6 tab switching

### DIFF
--- a/.config/vimium/README.md
+++ b/.config/vimium/README.md
@@ -1,0 +1,27 @@
+# Vimium C Configuration
+
+`vimium-c.json` is a [Vimium C](https://github.com/gdh1995/vimium-c) settings export. It is **not symlinked** — extensions read their settings from `chrome.storage`, not from disk, so `link.sh` has no destination to point at. The repo copy is the source of truth; the browser copy is applied by importing.
+
+## Apply to the browser
+
+Vimium C Options → *Backup and restore* → **Import** → pick this file → **Save**.
+
+There is no way to automate this. Browser extensions cannot read a local path like `~/.vimiumrc`; upstream declined the request for exactly that reason ([philc/vimium#3997](https://github.com/philc/vimium/issues/3997)). The only automatic propagation available is Chrome Sync (`vimSync: true`), which copies settings between signed-in browsers but never reads from this repo.
+
+## Update the repo copy
+
+Edit settings in the Options UI, then Options → *Backup and restore* → **Export** and overwrite this file. Exporting rewrites `@time` / `time` / `environment`, so those fields churn on every round trip — that is expected.
+
+Hand-editing `keyMappings` here and importing works too, and keeps the diff clean.
+
+## Current mappings
+
+```
+map <c-6> visitPreviousTab
+```
+
+Ctrl+6 jumps to the previously-visited tab — a toggle between two, not a history stack. It is the same chord and the same behaviour as nvim's `CTRL-^` (`:h CTRL-^`, alternate file; the terminal collapses Ctrl+6 and Ctrl+Shift+6 to the same byte, so `CTRL-^` answers to both) and Zed's `pane::AlternateFile`. **Zed only ships `ctrl-^`, so `.config/zed/keymap.json` adds `ctrl-6` explicitly** — change one side and the three stop matching.
+
+`<c-6>` is confirmed working; `<c-^>` was not tested. The default `^` binding for the same command is left in place.
+
+Vimium C is inactive on `chrome://` pages and the Chrome Web Store, where extensions cannot inject scripts — the key falls through to the browser there.

--- a/.config/vimium/vimium-c.json
+++ b/.config/vimium/vimium-c.json
@@ -1,0 +1,14 @@
+{
+	"name": "Vimium C",
+	"@time": "2026/8/1 16:28:14",
+	"time": 1785569294203,
+	"environment": {
+		"extension": "2.12.2",
+		"platform": "mac",
+		"chromium": 150
+	},
+	"exclusionRules": [],
+	"keyLayout": 2,
+	"vimSync": true,
+	"keyMappings": "map <c-6> visitPreviousTab\n"
+}

--- a/.config/zed/keymap.json
+++ b/.config/zed/keymap.json
@@ -23,5 +23,13 @@
       "alt-]": "pane::ActivateNextItem",
       "alt-[": "pane::ActivatePreviousItem"
     }
+  },
+  // 直前バッファへのトグル。Zed 既定は ctrl-^ (= Ctrl+Shift+6) のみ
+  // nvim / Vimium C は Ctrl+6 で通るので、3 つを同じ打鍵に揃えるための追加
+  {
+    "context": "VimControl && !menu",
+    "bindings": {
+      "ctrl-6": "pane::AlternateFile"
+    }
   }
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ zsh -n <file>   # zsh configs and .zshrc / .zshenv
 - **File Manager**: `.config/yazi/` (yazi config + projects plugin)
 - **Search**: `.config/fd/` (fd defaults)
 - **Input**: `.config/karabiner/` (keyboard remapping, TypeScript-based — see below)
+- **Browser**: `.config/vimium/vimium-c.json` (Vimium C settings export; import-only, not symlinked — see `.config/vimium/README.md`)
 - **Window Manager**: `.config/amethyst/amethyst.yml` (Amethyst; `screen-padding-*` is tied to the external monitor's logical width — see `docs/window-manager.md`)
 - **Claude Code**: `.config/claude/` (settings.json + commands/, symlinked to `~/.claude/`)
 

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -37,6 +37,10 @@ setup() {
   python3 -m json.tool .config/karabiner/karabiner.json >/dev/null
 }
 
+@test "vimium-c.json is valid JSON" {
+  python3 -m json.tool .config/vimium/vimium-c.json >/dev/null
+}
+
 @test "amethyst configuration exists" {
   [ -f .config/amethyst/amethyst.yml ]
 }


### PR DESCRIPTION
## Background / 背景

Chrome で「直前に見ていたタブへ戻る」操作に標準のショートカットが無い。Chrome のタブ移動はすべて並び順ベースで、MRU（最近使った順）の概念を持たない。

すでに Vimium C を入れているため、nvim の `CTRL-^`（alternate file）・Zed の `pane::AlternateFile` と**同じ打鍵・同じ挙動**をブラウザにも用意して、3 つのツールで操作を揃える。

## Changes / 変更内容

- `.config/vimium/vimium-c.json` を追加。`map <c-6> visitPreviousTab`
- `.config/vimium/README.md` を追加。import 手順と、symlink していない理由（拡張は設定を `chrome.storage` から読むためディスク上に読み先が無い）
- `.config/zed/keymap.json` に `ctrl-6` → `pane::AlternateFile` を追加。Zed の既定は `ctrl-^`（= Ctrl+Shift+6）のみで、Ctrl+6 では発火しない。nvim は端末が Ctrl+6 / Ctrl+Shift+6 を同じ 0x1E に潰すため既定のまま通る
- `CLAUDE.md` の Configuration Files に 1 行追加
- `tests/config.bats` に `vimium-c.json` の JSON 構文チェックを追加（手で編集するファイルのため）

## Impact scope / 影響範囲

- `link.sh` は変更なし。`vimium-c.json` は symlink 対象ではなく、Vimium C の Options から手動 import する
- Zed 既定の `ctrl-^` はそのまま残るため、Ctrl+Shift+6 も引き続き使える
- nvim の設定変更なし

## Testing / 動作確認

- [x] Chrome で Ctrl+6 が直前タブへのトグルとして動作する（import 済みの設定で確認）
- [x] Zed で Ctrl+6 が直前バッファへのトグルとして動作する
- [x] `bats tests/config.bats` が 10/10 pass