### PR TITLE
feat(lazygit): render diffs with delta

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,0 +1,7 @@
+gui:
+  sidePanelWidth: 0.2
+git:
+  pagers:
+    - colorArg: always
+      pager: delta --paging=never
+  mainPanelSplitMode: horizontal

--- a/.zshenv
+++ b/.zshenv
@@ -15,6 +15,9 @@ export PATH="$HOME/.local/share/mise/shims:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
 [ -f "$HOME/.cargo/env" ] && . "$HOME/.cargo/env"
 
+# lazygit reads ~/Library/Application Support on macOS; this points it at .config/lazygit/config.yml
+export LG_CONFIG_FILE="$HOME/.config/lazygit/config.yml"
+
 # fzf
 export FZF_DEFAULT_COMMAND='fd --type f --hidden --follow --exclude .git'
 export FZF_CTRL_T_COMMAND="$FZF_DEFAULT_COMMAND"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ zsh -n <file>   # zsh configs and .zshrc / .zshenv
 ### Configuration Files
 - **Shell**: `.zshrc` / `.zshenv` (main) + `.config/zsh/` (alias.sh, command.sh, hosts/)
 - **Runtime**: `.mise.toml` (Node.js LTS, bun, gcloud, terraform, biome, rust + rust-analyzer)
-- **Git**: `.gitconfig` (personal) + `.gitconfig-olta` (work, includeIf)
+- **Git**: `.gitconfig` (personal) + `.gitconfig-olta` (work, includeIf), `.config/lazygit/config.yml` (delta pager; found via `LG_CONFIG_FILE` in `.zshenv`, since lazygit defaults to `~/Library/Application Support`)
 - **Terminal**: `.config/ghostty/config`, `.config/tmux/tmux.conf` (→ `~/.tmux.conf`)
 - **Editor**: `.config/nvim/init.lua` (Neovim), `.config/zed/settings.json` (Zed)
 - **Prompt/Plugins**: `.config/starship/starship.toml` (→ `~/.config/starship.toml`), `.config/sheldon/plugins.toml`

--- a/link.sh
+++ b/link.sh
@@ -12,6 +12,7 @@ entries=(
   .config/ghostty/config
   .config/karabiner/HRM.md
   .config/karabiner/karabiner.json
+  .config/lazygit/config.yml
   .config/nvim
   .config/sheldon/plugins.toml
   .config/tmux/yazi-picker.sh


### PR DESCRIPTION
## Background / 背景

lazygit の diff を delta で side-by-side 表示したかったが、設定が反映されなかった。macOS の lazygit は `~/.config/lazygit/` ではなく `~/Library/Application Support/lazygit/` を参照するため（`lazygit --print-config-dir` で確認）、`~/.config` に置いた設定が読まれていなかった。

## Changes / 変更内容

- `.config/lazygit/config.yml` を追加し、pager に delta を指定（side-by-side は `.gitconfig` の `[delta]` 設定が効く）
- `.zshenv` に `LG_CONFIG_FILE` を追加し、設定ファイルの参照先を `~/.config/lazygit/config.yml` に向ける。`.zshrc` ではなく `.zshenv` に置くのは非対話シェルでも読ませるため
- サイドパネル幅を 0.2 に狭め、メインパネルを広く取る
- `mainPanelSplitMode: horizontal` で staged / unstaged を上下分割にし、diff の横幅を確保する

## Impact scope / 影響範囲

lazygit の表示のみ。ターミナルの `git diff` の見え方は変わらない。

## Testing / 動作確認

- [x] `bats tests/link.bats tests/config.bats` 全 16 件 pass
- [x] shellcheck / shfmt / `zsh -n .zshenv` clean
- [x] lazygit が `LG_CONFIG_FILE` を参照することを確認（不正な型の設定を渡してパースエラーになること）
- [x] `./link.sh` で `~/.config/lazygit/config.yml` が symlink されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)