### PR TITLE
chore(amethyst): widen centered column to 2040px

### DIFF
--- a/.config/amethyst/amethyst.yml
+++ b/.config/amethyst/amethyst.yml
@@ -2,9 +2,9 @@ layouts:
   - fullscreen
 
 # The LG ULTRAGEAR is 3440px wide with no HiDPI, so a full-width window is unusable.
-# 860 leaves a centered 1720px column; the built-in display is excluded so it stays full screen.
-screen-padding-left: 860
-screen-padding-right: 860
+# 700 leaves a centered 2040px column; the built-in display is excluded so it stays full screen.
+screen-padding-left: 700
+screen-padding-right: 700
 screen-padding-top: 0
 screen-padding-bottom: 0
 disable-padding-on-builtin-display: true

--- a/docs/window-manager.md
+++ b/docs/window-manager.md
@@ -7,7 +7,7 @@
 | # | 要件 | 理由 |
 |---|---|---|
 | 1 | アプリ切り替えは Raycast の per-app hotkey を維持する | 既に定着している主動線。ここを捨てる移行はしない |
-| 2 | LG では中央 1720px、内蔵では全画面 | 3440px の全幅は視線移動が大きく、首肩対策と逆行する |
+| 2 | LG では中央 2040px、内蔵では全画面 | 3440px の全幅は視線移動が大きく、首肩対策と逆行する |
 | 3 | モニタ着脱で崩れない | これが元の課題 |
 | 4 | 設定が dotfiles に載る | GUI に閉じる設定は管理外になる（→ [raycast-dotfiles.md](raycast-dotfiles.md)） |
 
@@ -36,16 +36,28 @@ Amethyst は **native の macOS Space をそのまま使う**。ウィンドウ�
 
 ```yaml
 layouts: [fullscreen]
-screen-padding-left: 860
-screen-padding-right: 860
+screen-padding-left: 700
+screen-padding-right: 700
 disable-padding-on-builtin-display: true
 ```
 
-- **padding の単位は px。** LG は HiDPI なし（`UI Looks like: 3440 x 1440`）なので px = pt として扱える。860 で中央 1720px が残る
-- **`disable-padding-on-builtin-display: true` が必須。** 内蔵は Retina（2x）で論理幅が 1720px より狭いため、同じ px 値を共有できない。このキーで内蔵だけ padding 対象から外し、全画面のまま使う
-- モニタを買い替えたら `860` は再計算が必要（`system_profiler SPDisplaysDataType` の `UI Looks like` を見る）
+- **padding の単位は px。** LG は HiDPI なし（`UI Looks like: 3440 x 1440`）なので px = pt として扱える。700 で中央 2040px が残る
+- **`disable-padding-on-builtin-display: true` が必須。** 内蔵は Retina（2x）で論理幅が 2040px より狭いため、同じ px 値を共有できない。このキーで内蔵だけ padding 対象から外し、全画面のまま使う
+- モニタを買い替えたら `700` は再計算が必要（`system_profiler SPDisplaysDataType` の `UI Looks like` を見る）
+- 当初は 860（中央 1720px）だったが、ターミナルと Chrome が狭かったため 2026-08 に 2040px へ広げた
 
-`mod1`（既定 `option + shift`）と `mod2` は、修飾キーを盛って事実上無効化している。Karabiner の HRM で `S` ホールドが Opt を出すため、既定のままだとタイプ中に暴発する（→ [../.config/karabiner/HRM.md](../.config/karabiner/HRM.md)）。ウィンドウ操作は Raycast に任せるので、Amethyst 側のバインドは不要。
+`mod1`（既定 `option + shift`）と `mod2` は、修飾キーを盛って事実上無効化している。Karabiner の HRM で `S` ホールドが Opt を出すため、既定のままだとタイプ中に暴発する（→ [../.config/karabiner/HRM.md](../.config/karabiner/HRM.md)）。ウィンドウの切り替え自体は Raycast に任せるので、移動・フォーカス系のバインドは使わない。
+
+例外として、一時的に fullscreen レイアウトから外したいときに次の 2 つを使う。
+
+- `toggle-float`（`mod1 + t` = ⌥⇧⌃⌘+T） — フォーカス中のウィンドウだけをタイル管理から外す。もう一度押すとタイルに復帰する
+- `toggle-tiling`（`mod2 + t` = ⇧⌃⌘+T） — タイリング自体を停止する
+
+`;` ホールドは ⌘⌥⌃ 止まり（中国語変換サービスとの衝突回避）なので、`mod1` は `;` ホールド + Shift で出す。**`;` は 200ms 以上ホールドしてから T を叩く**（`basic.to_if_held_down_threshold_milliseconds`）。速く叩くと `;` がリテラルとして出るだけで何も起きない。
+
+**`toggle-float` は見た目を変えない。** ウィンドウを管理対象から外すだけで、サイズも位置も動かさない。効いたかどうかは「その後リサイズして維持されるか」でしか分からないので、無反応に見えても失敗とは限らない。
+
+`mod1`/`mod2` は Amethyst が起動時に UserDefaults へ移行する（`migrated-toggle-float` 等）。yml を直したのに効かないときは `defaults read com.amethyst.Amethyst | grep KeyboardShortcuts_` で実際の登録内容を見る（`carbonModifiers` は `⌘256 / ⇧512 / ⌥2048 / ⌃4096` の和）。
 
 ## 触っていない設定
 

--- a/docs/window-manager.md
+++ b/docs/window-manager.md
@@ -59,6 +59,28 @@ disable-padding-on-builtin-display: true
 
 `mod1`/`mod2` は Amethyst が起動時に UserDefaults へ移行する（`migrated-toggle-float` 等）。yml を直したのに効かないときは `defaults read com.amethyst.Amethyst | grep KeyboardShortcuts_` で実際の登録内容を見る（`carbonModifiers` は `⌘256 / ⇧512 / ⌥2048 / ⌃4096` の和）。
 
+## LG より狭い外部モニタでは破綻する
+
+`screen-padding-*` は**内蔵以外のすべての外部ディスプレイに同じ px 値が一律で適用される**。`Screen.swift` の `adjustedFrame` は下限をクランプしないため、幅から常に 1400px（700 × 2）が引かれるだけになる。
+
+```swift
+frame.origin.x += paddingLeft
+frame.size.width -= (paddingRight + paddingLeft)
+```
+
+判定に使われるのは**論理幅（`UI Looks like`）**で物理解像度ではない。4K を既定スケールで繋ぐと論理 1920 になるため、ここが罠になる。
+
+| 論理幅 | ウィンドウ幅 |
+|---|---|
+| 3440（LG） | 2040 |
+| 2560（WQHD、HiDPI なし） | 1160 |
+| 1920（FHD / 4K の既定スケール） | 520 |
+| 1400 以下 | 0 または負（ガードなし） |
+
+**一時的に別のモニタへ繋ぐだけなら `toggle-tiling`（⇧⌃⌘+T）で止める。** タイリングごと止まるので padding も効かなくなり、yml を触らずに macOS 通常のウィンドウ操作へ戻れる。常用するモニタが増えたときだけ値を書き換える。
+
+`window-minimum-width` で下限を守れる可能性はあるが**未検証**（2 台目の外部モニタで実機確認していない）。
+
 ## 触っていない設定
 
 **「ディスプレイごとに個別の操作スペース」は ON のまま。** AeroSpace の公式は OFF を推奨していたが、その根拠は主に native フルスクリーンとマルチモニタのフォーカス不具合で、Space 1 枚・native フルスクリーン未使用の構成では効く場面が限られる。しかも OFF にするとメニューバーが片方の画面にしか出なくなり、今より不便になる。フォーカスの不具合が実際に出たら `defaults write com.apple.spaces spans-displays` を `settings.sh` に追加する（再ログインが必要）。
@@ -72,6 +94,7 @@ disable-padding-on-builtin-display: true
 ## 再検討のトリガー
 
 - 外部モニタを買い替えたとき → `screen-padding-*` の再計算
+- LG より狭い外部モニタを常用するようになったとき → padding はグローバル値なので両立できない。`window-minimum-width` の検証か、片方を諦める判断が必要
 - native フルスクリーンを使い始めたとき → Amethyst と衝突するため設計を見直す
 - 内蔵と外部の両方に別のアプリを常時出したくなったとき → 現構成は「全アプリを1画面に集約」前提
 
@@ -84,4 +107,5 @@ disable-padding-on-builtin-display: true
 
 - [Amethyst 公式サイト](https://ianyh.com/amethyst/)
 - [Amethyst - Configuration Files](https://github.com/ianyh/Amethyst/blob/development/docs/configuration-files.md)
+- [Amethyst - Screen.swift](https://github.com/ianyh/Amethyst/blob/development/Amethyst/Model/Screen.swift) — `adjustedFrame` の padding 適用箇所
 - [AeroSpace Guide](https://nikitabobko.github.io/AeroSpace/guide)


### PR DESCRIPTION
## Background / 背景

外部モニタ（LG ULTRAGEAR / 3440x1440）で ghostty や Chrome のサイズを変更してもすぐ元に戻る、という症状の原因は Amethyst の `fullscreen` レイアウトだった。仕様どおりの挙動だが、中央 1720px はターミナルと Chrome には狭かった。

また調査の過程で 2 点分かった。

- 一時的に拡大したいときの `toggle-float` は、押しても「何も起きない」ように見える。実際には効いているがウィンドウを動かさないだけ。`docs/window-manager.md` には「Amethyst 側のバインドは不要」と書いてあり実態とズレていた
- `screen-padding-*` は外部ディスプレイ全体に一律で適用され下限のクランプもないため、LG より狭いモニタを繋ぐと破綻する

## Changes / 変更内容

- `.config/amethyst/amethyst.yml`: `screen-padding-left` / `screen-padding-right` を 860 → 700 に変更（中央 1720px → 2040px）
- `docs/window-manager.md`:
  - 幅の記述を 2040px に更新し、変更理由を追記
  - `toggle-float`（⌥⇧⌃⌘+T）と `toggle-tiling`（⇧⌃⌘+T）のキーを追記
  - `toggle-float` はウィンドウを動かさないため無反応に見えることを明記
  - `;` は 200ms 以上ホールドしてから T を叩く必要があることを明記
  - yml の `mod1` / `mod2` は Amethyst が起動時に UserDefaults へ移行するため、`defaults read com.amethyst.Amethyst | grep KeyboardShortcuts_` で実物を確認する手順を追記
  - 「LG より狭い外部モニタでは破綻する」節を追加。論理幅ごとのウィンドウ幅と、一時接続時は `toggle-tiling` で止める回避策を記載
  - 再検討のトリガーに「狭いモニタを常用するようになったとき」を追加

## Impact scope / 影響範囲

外部モニタ接続時のウィンドウ幅のみ。内蔵ディスプレイは `disable-padding-on-builtin-display: true` により padding 対象外なので影響なし。キーバインドの変更はなく、それ以外は docs への追記のみ。

## Testing / 動作確認

- [x] `bats tests/config.bats` が通る（amethyst.yml の YAML 妥当性を含む 10 件すべて ok）
- [x] Amethyst の Reload Configuration 後、`defaults read com.amethyst.Amethyst` で `screen-padding-left = 700` を確認
- [x] `defaults read com.amethyst.Amethyst | grep KeyboardShortcuts_` で `toggle-float` = keyCode 17 / modifiers 6912（⌃⌥⇧⌘+T）を確認
- [x] `;` を 200ms 以上ホールドしてから T でフロートに切り替わることを実機で確認

未検証:

- フロート解除（同キー再押下）で 2040px に戻る挙動は未確認
- 狭い外部モニタでの挙動は `Screen.swift` と設定ドキュメントからの導出で、実機確認はしていない（2 台目の外部モニタが手元にないため）。`window-minimum-width` による回避も未検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)