### PR TITLE
fix(karabiner): drop Ctrl+W / Ctrl+V page remap

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -28,8 +28,6 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 | ------------------------- | -------------------------------------------- |
 | Ctrl + h / j / k / l      | ← / ↓ / ↑ / →                                |
 | Ctrl + , / .              | Option + ← / →  (word jump)                  |
-| Ctrl + w                  | Page Up                                      |
-| Ctrl + v                  | Page Down                                    |
 | Ctrl + Space  (terminal)  | 英数 → Ctrl+Space  (tmux prefix と同時に IME 抜け) |
 | Ctrl + g  (zsh)           | clear-screen  (Ctrl+L が → に潰れる代替)     |
 | Ctrl + P, Ctrl + O  (zsh) | 現在行を pbcopy                              |

--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -86,7 +86,7 @@
             ]
           },
           {
-            "description": "Ctrl navigation (hjkl / word / page)",
+            "description": "Ctrl navigation (hjkl / word)",
             "manipulators": [
               {
                 "type": "basic",
@@ -129,44 +129,6 @@
                     "modifiers": [
                       "left_option"
                     ]
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "w",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "page_up"
-                  }
-                ]
-              },
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "v",
-                  "modifiers": {
-                    "mandatory": [
-                      "left_control"
-                    ],
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "page_down"
                   }
                 ]
               },

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -90,7 +90,7 @@ writeToProfile('Default profile', [
       .to({ key_code: 'spacebar', modifiers: ['left_control'] }),
   ]),
 
-  rule('Ctrl navigation (hjkl / word / page)').manipulators([
+  rule('Ctrl navigation (hjkl / word)').manipulators([
     map({
       key_code: 'comma',
       modifiers: { mandatory: ['left_control'], optional: ['any'] },
@@ -100,16 +100,6 @@ writeToProfile('Default profile', [
       key_code: 'period',
       modifiers: { mandatory: ['left_control'], optional: ['any'] },
     }).to({ key_code: 'right_arrow', modifiers: ['left_option'] }),
-
-    map({
-      key_code: 'w',
-      modifiers: { mandatory: ['left_control'], optional: ['any'] },
-    }).to({ key_code: 'page_up' }),
-
-    map({
-      key_code: 'v',
-      modifiers: { mandatory: ['left_control'], optional: ['any'] },
-    }).to({ key_code: 'page_down' }),
 
     withMapper({
       h: 'left_arrow',

--- a/docs/terminal-workflow.md
+++ b/docs/terminal-workflow.md
@@ -72,13 +72,10 @@
 - ファイル内容を表示 — `bat ファイル`
 - ファイル一覧 — `ls` / `l`
 - 後方 / 前方へ単語移動 — `⌥+←` / `⌥+→`（`Ctrl+,` / `Ctrl+.` でも可）
-- 後方へ単語削除 — `⌥+Backspace`
+- 後方へ単語削除 — `Ctrl+W`（`⌥+Backspace` でも可）
 - 前方へ単語削除 — `⌥+D`
 - 現在のコマンドラインをコピー — `Ctrl+P` → `Ctrl+O`
 - 画面クリア — `Ctrl+G`
-
-> **`Ctrl+W` は単語削除にならない**（Page Up に再マップ済み・末尾に `~` が残る）。
-> 後方単語削除は `⌥+Backspace`。
 
 ## Keyboard Shortcuts (Karabiner / HRM)
 
@@ -99,7 +96,6 @@ Ctrl navigation（D ホールドで Ctrl を作って発火・全アプリ）:
 
 - 矢印キー（左/下/上/右）— `Ctrl+H/J/K/L`
 - 単語単位で左/右移動 — `Ctrl+,` / `Ctrl+.`
-- Page Up / Page Down — `Ctrl+W` / `Ctrl+V`
 
 ターミナル限定:
 


### PR DESCRIPTION
## Background / 背景

ターミナルで `Ctrl+W` によるワード単位削除が効かなかった。原因は Karabiner が `Ctrl+W` → `Page Up` / `Ctrl+V` → `Page Down` にアプリ条件なしで再マップしていたことで、zsh の `backward-kill-word` / `quoted-insert` と nvim の `C-w`（ウィンドウプレフィックス）/ `C-v`（ビジュアルブロック）が潰されていた。

Page Up / Down 自体はスクロールを tmux と Vimium で行うため使っていない。加えて tmux の root キーテーブルに `PPage` バインドが無いため、tmux 内では再マップが `~` を挿入するだけで機能していなかった。

## Changes / 変更内容

- `karabiner.ts`: `Ctrl+W` / `Ctrl+V` のマッピングを削除し、rule 名を `Ctrl navigation (hjkl / word)` に変更
- `karabiner.json`: `bun run build` で再生成
- `HRM.md`: Ctrl navigation の表から該当 2 行を削除
- `docs/terminal-workflow.md`: 「`Ctrl+W` は単語削除にならない」注記を削除し、後方単語削除を `Ctrl+W`（`⌥+Backspace` でも可）に更新

## Impact scope / 影響範囲

- zsh: `Ctrl+W` = `backward-kill-word`、`Ctrl+V` = `quoted-insert` が有効化
- nvim: `C-w` プレフィックス（`C-w s` / `C-w v` / `C-w q`）と `C-v` ビジュアルブロックが有効化
- 全アプリで `Ctrl+W` / `Ctrl+V` の Page Up / Down は無効になる
- `Ctrl+,` / `Ctrl+.`（ワード移動）と `Ctrl+H/J/K/L`（矢印）は変更なし

## Testing / 動作確認

- [x] `bun run build` でプロファイル再生成・reload 完了
- [x] `~/.config/karabiner/karabiner.json`（実際に効いている設定）から `page_up` / `page_down` が消えたことを確認
- [x] repo 側 json と実設定のルール部分が完全一致することを確認
- [x] `bats tests/karabiner.bats` 通過
- [x] `zsh -ic 'bindkey'` で `"^W" backward-kill-word` のバインドを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)