### PR TITLE
chore(karabiner): manage simple modifications in karabiner.ts

### DIFF
--- a/.config/karabiner/README.md
+++ b/.config/karabiner/README.md
@@ -9,4 +9,8 @@ bun run build   # generate karabiner.json, sync back to repo, reload profile
 
 `build` regenerates the config, copies `~/.config/karabiner/karabiner.json` back into the repo (Karabiner's atomic writes break the symlink otherwise), and reloads the profile via `karabiner_cli`.
 
+## Simple Modifications
+
+Complex modifications だけでなく Simple Modifications (`caps_lock` → `left_control`) も `karabiner.ts` の `SIMPLE_MODIFICATIONS` から生成される (`writeToProfile` の第 4 引数)。**GUI の Simple Modifications 画面で追加しない** — `karabiner.ts` に書く。GUI で追加すると `profiles[].devices[].simple_modifications` に入り、`writeToProfile` が上書きしないためソースが二重化する。
+
 See `HRM.md` for the Home Row Mods design notes.

--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -7582,30 +7582,23 @@
           "mouse_motion_to_scroll.speed": 100
         }
       },
-      "devices": [
-        {
-          "identifiers": {
-            "is_keyboard": true
-          },
-          "simple_modifications": [
-            {
-              "from": {
-                "key_code": "caps_lock"
-              },
-              "to": [
-                {
-                  "key_code": "left_control"
-                }
-              ]
-            }
-          ]
-        }
-      ],
       "name": "Default profile",
       "selected": true,
       "virtual_hid_keyboard": {
         "keyboard_type_v2": "ansi"
-      }
+      },
+      "simple_modifications": [
+        {
+          "to": [
+            {
+              "key_code": "left_control"
+            }
+          ],
+          "from": {
+            "key_code": "caps_lock"
+          }
+        }
+      ]
     }
   ]
 }

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -75,6 +75,11 @@ function homeRowMod(opts: {
   ];
 }
 
+// simple modification のまま置く。Karabiner は simple → complex の順に適用するので
+// caps_lock は left_control として下の complex ルール群に流れる。complex 側の
+// map('caps_lock').to('left_control') に置き換えると出力が再評価されず chain が切れる。
+const SIMPLE_MODIFICATIONS = [map('caps_lock').to('left_control')];
+
 writeToProfile('Default profile', [
   rule('Terminal Ctrl tap-hold + tmux IME bypass', ifTerminal).manipulators([
     map({ key_code: 'left_control', modifiers: { optional: ['any'] } })
@@ -168,4 +173,4 @@ writeToProfile('Default profile', [
         .parameters({ 'basic.to_if_held_down_threshold_milliseconds': 100 }),
     ),
   ]),
-]);
+], undefined, { simple_modifications: SIMPLE_MODIFICATIONS });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ zsh -n <file>   # zsh configs and .zshrc / .zshenv
 - **Claude Code**: `.config/claude/` (settings.json + commands/, symlinked to `~/.claude/`)
 
 ### Karabiner (TypeScript build)
-`karabiner.json` is generated from `karabiner.ts` using the karabiner.ts library. Never edit `karabiner.json` directly — edit `karabiner.ts` and build:
+`karabiner.json` is generated from `karabiner.ts` using the karabiner.ts library. Never edit `karabiner.json` directly, and never add Simple Modifications from the Karabiner GUI (they live in `karabiner.ts`'s `SIMPLE_MODIFICATIONS` too) — edit `karabiner.ts` and build:
 
 ```bash
 cd .config/karabiner && bun run build  # generate → sync repo copy → reload profile


### PR DESCRIPTION
## Background / 背景

Karabiner の Simple Modifications（`caps_lock` → `left_control`）が `karabiner.ts` の管理外だった。GUI で設定した内容が `profiles[].devices[]` に入っており、`writeToProfile` は `complex_modifications` しか書き換えないため（`node_modules/karabiner.ts/dist/index.js:1826-1834`）、`bun run build` の sync でリポジトリに転写されるだけの状態だった。復元自体は機能するが、GUI とリポジトリで正が二重になっていた。

karabiner.ts v1.38.0 の `writeToProfile` は第 4 引数 `extras.simple_modifications` を持っており（`dist/index.d.ts:1157-1165`）、simple modification のまま TS から生成できる。

complex modification（`map('caps_lock').to('left_control')`）に寄せる形は採らなかった。[Input event modification chaining](https://karabiner-elements.pqrs.org/docs/manual/misc/event-modification-chaining/) にあるとおり Karabiner は simple → complex の順に適用するため、現状 `caps_lock` は `left_control` として `Terminal Ctrl tap-hold + tmux IME bypass` ルールに流れている。complex 化すると出力が再評価されず、この chain が切れて caps_lock タップの 300ms ホールド（tmux prefix 用）が失われる。

## Changes / 変更内容

- `karabiner.ts`: `SIMPLE_MODIFICATIONS` を定義し、`writeToProfile` の第 4 引数で渡す。complex 化してはいけない理由をコメントで残す
- `karabiner.json`: GUI 由来の `profiles[].devices[]` を削除（中身は caps_lock マッピングのみで他のデバイス設定は無し）、`profiles[].simple_modifications` を生成
- `.config/karabiner/README.md`: Simple Modifications を GUI で追加しない旨と理由を追記
- `CLAUDE.md`: Karabiner セクションに同様の注記

## Impact scope / 影響範囲

キー挙動の変更はない。`caps_lock` → `left_control` は simple modification のままなので、`Terminal Ctrl tap-hold` / `Ctrl navigation (hjkl)` / tmux prefix への chain も従来どおり。

設定の格納位置が device 単位（`devices[{is_keyboard: true}]`）から profile 単位（`simple_modifications`）に移るため、GUI の Simple Modifications 画面では該当行がデバイスタブから「For all devices」側に表示される。

## Testing / 動作確認

- [x] `bun run build` 実行後、`core_service.log` に `Load .../karabiner.json...` → `core_configuration is updated.` を確認
- [x] 反映後の live config が `devices: null` / `simple_modifications: [caps_lock → left_control]` になり、Karabiner が GUI 由来の設定を復活させないことを確認
- [x] 再生成の冪等性を sha256 一致で確認（`tests/karabiner.bats` と同じ判定を fake HOME 上で実行し pass）
- [x] `bats tests/config.bats tests/link.bats` 全 16 件 pass
- [x] `biome lint karabiner.ts` clean
