### PR TITLE
chore(karabiner): scope complex rules to built-in keyboard

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -2,6 +2,8 @@
 
 source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/tmux/tmux.conf`
 
+適用対象は **Mac 内蔵キーボードのみ** (`ifBuiltIn` = `device_if: is_built_in_keyboard`)。外付けキーボード (7sPro) は QMK 側でキーマップを完結させるため Karabiner を通さない。以下の Scope 列の「All apps」は内蔵キーボード上での話。
+
 ## Modifier mappings
 
 | Key             | Hold → Modifier | Scope                                 |

--- a/.config/karabiner/README.md
+++ b/.config/karabiner/README.md
@@ -9,6 +9,12 @@ bun run build   # generate karabiner.json, sync back to repo, reload profile
 
 `build` regenerates the config, copies `~/.config/karabiner/karabiner.json` back into the repo (Karabiner's atomic writes break the symlink otherwise), and reloads the profile via `karabiner_cli`.
 
+## Scope: 内蔵キーボードのみ
+
+Complex modifications の全 rule に `ifBuiltIn` (`device_if: is_built_in_keyboard`) を付けている。外付けキーボード (7sPro) は QMK でキーマップを組むため、Karabiner 側と二重に適用させない。**rule を追加するときも必ず付ける。**
+
+Simple Modifications (`caps_lock` → `left_control`) はデバイス条件を持てない (Karabiner のスキーマ上 profile 全体に効く。per-device 版は `profiles[].devices[].simple_modifications` だが `writeToProfile` は書き込まない)。外付け側では `caps_lock` を送らない (QMK で直接 Ctrl に割り当てる) ことで回避する。
+
 ## Simple Modifications
 
 Complex modifications だけでなく Simple Modifications (`caps_lock` → `left_control`) も `karabiner.ts` の `SIMPLE_MODIFICATIONS` から生成される (`writeToProfile` の第 4 引数)。**GUI の Simple Modifications 画面で追加しない** — `karabiner.ts` に書く。GUI で追加すると `profiles[].devices[].simple_modifications` に入り、`writeToProfile` が上書きしないためソースが二重化する。

--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -33,6 +33,14 @@
                 },
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_if",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -71,6 +79,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_if",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -108,6 +124,16 @@
                       "left_option"
                     ]
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -130,6 +156,16 @@
                       "left_option"
                     ]
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -148,6 +184,16 @@
                 "to": [
                   {
                     "key_code": "left_arrow"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -168,6 +214,16 @@
                   {
                     "key_code": "down_arrow"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -187,6 +243,16 @@
                   {
                     "key_code": "up_arrow"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -205,6 +271,16 @@
                 "to": [
                   {
                     "key_code": "right_arrow"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               }
@@ -241,7 +317,17 @@
                 "parameters": {
                   "basic.to_if_alone_timeout_milliseconds": 200,
                   "basic.to_if_held_down_threshold_milliseconds": 200
-                }
+                },
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -273,6 +359,16 @@
                   {
                     "key_code": "q"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -300,6 +396,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -327,6 +433,16 @@
                   {
                     "key_code": "w"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -353,6 +469,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -381,6 +507,16 @@
                   {
                     "key_code": "e"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -408,6 +544,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -435,6 +581,16 @@
                   {
                     "key_code": "r"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -461,6 +617,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -489,6 +655,16 @@
                   {
                     "key_code": "t"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -516,6 +692,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -543,6 +729,16 @@
                   {
                     "key_code": "a"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -569,6 +765,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -597,6 +803,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -624,6 +840,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -651,6 +877,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -677,6 +913,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -705,6 +951,16 @@
                   {
                     "key_code": "g"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -732,6 +988,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -759,6 +1025,16 @@
                   {
                     "key_code": "z"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -785,6 +1061,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -813,6 +1099,16 @@
                   {
                     "key_code": "x"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -840,6 +1136,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -867,6 +1173,16 @@
                   {
                     "key_code": "c"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -893,6 +1209,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -921,6 +1247,16 @@
                   {
                     "key_code": "v"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -948,6 +1284,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -975,6 +1321,16 @@
                   {
                     "key_code": "b"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1001,6 +1357,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1029,6 +1395,16 @@
                   {
                     "key_code": "y"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1056,6 +1432,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1083,6 +1469,16 @@
                   {
                     "key_code": "u"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1109,6 +1505,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1137,6 +1543,16 @@
                   {
                     "key_code": "i"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1164,6 +1580,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1191,6 +1617,16 @@
                   {
                     "key_code": "o"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1217,6 +1653,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1245,6 +1691,16 @@
                   {
                     "key_code": "p"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1272,6 +1728,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1299,6 +1765,16 @@
                   {
                     "key_code": "h"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1325,6 +1801,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1353,6 +1839,16 @@
                   {
                     "key_code": "j"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1380,6 +1876,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1407,6 +1913,16 @@
                   {
                     "key_code": "k"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1433,6 +1949,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1461,6 +1987,16 @@
                   {
                     "key_code": "l"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1488,6 +2024,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1515,6 +2061,16 @@
                   {
                     "key_code": "semicolon"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1541,6 +2097,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1569,6 +2135,16 @@
                   {
                     "key_code": "n"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1596,6 +2172,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1623,6 +2209,16 @@
                   {
                     "key_code": "m"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1649,6 +2245,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1677,6 +2283,16 @@
                   {
                     "key_code": "comma"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1704,6 +2320,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1731,6 +2357,16 @@
                   {
                     "key_code": "period"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1757,6 +2393,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1785,6 +2431,16 @@
                   {
                     "key_code": "slash"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1811,6 +2467,16 @@
                   },
                   {
                     "key_code": "f"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1838,7 +2504,17 @@
                 "parameters": {
                   "basic.to_if_alone_timeout_milliseconds": 200,
                   "basic.to_if_held_down_threshold_milliseconds": 200
-                }
+                },
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "type": "basic",
@@ -1864,6 +2540,16 @@
                   },
                   {
                     "key_code": "q"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1891,6 +2577,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -1919,6 +2615,16 @@
                   {
                     "key_code": "w"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1946,6 +2652,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1973,6 +2689,16 @@
                   {
                     "key_code": "e"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -1999,6 +2725,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2027,6 +2763,16 @@
                   {
                     "key_code": "r"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2054,6 +2800,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2081,6 +2837,16 @@
                   {
                     "key_code": "t"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2107,6 +2873,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2135,6 +2911,16 @@
                   {
                     "key_code": "a"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2162,6 +2948,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2189,6 +2985,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2215,6 +3021,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2243,6 +3059,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2270,6 +3096,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2297,6 +3133,16 @@
                   {
                     "key_code": "g"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2323,6 +3169,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2351,6 +3207,16 @@
                   {
                     "key_code": "z"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2378,6 +3244,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2405,6 +3281,16 @@
                   {
                     "key_code": "x"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2431,6 +3317,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2459,6 +3355,16 @@
                   {
                     "key_code": "c"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2486,6 +3392,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2513,6 +3429,16 @@
                   {
                     "key_code": "v"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2539,6 +3465,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2567,6 +3503,16 @@
                   {
                     "key_code": "b"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2594,6 +3540,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2621,6 +3577,16 @@
                   {
                     "key_code": "y"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2647,6 +3613,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2675,6 +3651,16 @@
                   {
                     "key_code": "u"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2702,6 +3688,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2729,6 +3725,16 @@
                   {
                     "key_code": "i"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2755,6 +3761,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2783,6 +3799,16 @@
                   {
                     "key_code": "o"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2810,6 +3836,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2837,6 +3873,16 @@
                   {
                     "key_code": "p"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2863,6 +3909,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2891,6 +3947,16 @@
                   {
                     "key_code": "h"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2918,6 +3984,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2945,6 +4021,16 @@
                   {
                     "key_code": "j"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -2971,6 +4057,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -2999,6 +4095,16 @@
                   {
                     "key_code": "k"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3026,6 +4132,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3053,6 +4169,16 @@
                   {
                     "key_code": "l"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3079,6 +4205,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3107,6 +4243,16 @@
                   {
                     "key_code": "semicolon"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3134,6 +4280,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3161,6 +4317,16 @@
                   {
                     "key_code": "n"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3187,6 +4353,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3215,6 +4391,16 @@
                   {
                     "key_code": "m"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3242,6 +4428,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3269,6 +4465,16 @@
                   {
                     "key_code": "comma"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3295,6 +4501,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3323,6 +4539,16 @@
                   {
                     "key_code": "period"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3350,6 +4576,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3377,6 +4613,16 @@
                   {
                     "key_code": "slash"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3403,6 +4649,16 @@
                   },
                   {
                     "key_code": "s"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3430,7 +4686,17 @@
                 "parameters": {
                   "basic.to_if_alone_timeout_milliseconds": 200,
                   "basic.to_if_held_down_threshold_milliseconds": 200
-                }
+                },
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "type": "basic",
@@ -3456,6 +4722,16 @@
                   },
                   {
                     "key_code": "q"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3483,6 +4759,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3511,6 +4797,16 @@
                   {
                     "key_code": "w"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3538,6 +4834,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3565,6 +4871,16 @@
                   {
                     "key_code": "e"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3591,6 +4907,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3619,6 +4945,16 @@
                   {
                     "key_code": "r"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3646,6 +4982,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3673,6 +5019,16 @@
                   {
                     "key_code": "t"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3699,6 +5055,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3727,6 +5093,16 @@
                   {
                     "key_code": "a"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3754,6 +5130,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3781,6 +5167,16 @@
                   {
                     "key_code": "s"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3807,6 +5203,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3835,6 +5241,16 @@
                   {
                     "key_code": "f"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3862,6 +5278,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3889,6 +5315,16 @@
                   {
                     "key_code": "g"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3915,6 +5351,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -3943,6 +5389,16 @@
                   {
                     "key_code": "z"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3970,6 +5426,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -3997,6 +5463,16 @@
                   {
                     "key_code": "x"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4023,6 +5499,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4051,6 +5537,16 @@
                   {
                     "key_code": "c"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4078,6 +5574,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4105,6 +5611,16 @@
                   {
                     "key_code": "v"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4131,6 +5647,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4159,6 +5685,16 @@
                   {
                     "key_code": "b"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4186,6 +5722,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4213,6 +5759,16 @@
                   {
                     "key_code": "y"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4239,6 +5795,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4267,6 +5833,16 @@
                   {
                     "key_code": "u"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4294,6 +5870,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4321,6 +5907,16 @@
                   {
                     "key_code": "i"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4347,6 +5943,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4375,6 +5981,16 @@
                   {
                     "key_code": "o"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4402,6 +6018,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4429,6 +6055,16 @@
                   {
                     "key_code": "p"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4455,6 +6091,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4483,6 +6129,16 @@
                   {
                     "key_code": "h"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4510,6 +6166,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4537,6 +6203,16 @@
                   {
                     "key_code": "j"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4563,6 +6239,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4591,6 +6277,16 @@
                   {
                     "key_code": "k"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4618,6 +6314,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4645,6 +6351,16 @@
                   {
                     "key_code": "l"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4671,6 +6387,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4699,6 +6425,16 @@
                   {
                     "key_code": "semicolon"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4726,6 +6462,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4753,6 +6499,16 @@
                   {
                     "key_code": "n"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4779,6 +6535,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4807,6 +6573,16 @@
                   {
                     "key_code": "m"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4834,6 +6610,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4861,6 +6647,16 @@
                   {
                     "key_code": "comma"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4887,6 +6683,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -4915,6 +6721,16 @@
                   {
                     "key_code": "period"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4942,6 +6758,16 @@
                   {
                     "key_code": "d"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4969,6 +6795,16 @@
                   {
                     "key_code": "slash"
                   }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
                 ]
               },
               {
@@ -4995,6 +6831,16 @@
                   },
                   {
                     "key_code": "d"
+                  }
+                ],
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
                   }
                 ]
               },
@@ -5022,7 +6868,17 @@
                 "parameters": {
                   "basic.to_if_alone_timeout_milliseconds": 200,
                   "basic.to_if_held_down_threshold_milliseconds": 200
-                }
+                },
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },
@@ -5057,6 +6913,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5099,6 +6963,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5141,6 +7013,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5182,6 +7062,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -5225,6 +7113,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5267,6 +7163,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5309,6 +7213,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5350,6 +7262,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -5393,6 +7313,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5435,6 +7363,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5477,6 +7413,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5518,6 +7462,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -5561,6 +7513,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5603,6 +7563,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5645,6 +7613,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5686,6 +7662,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -5729,6 +7713,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5771,6 +7763,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5813,6 +7813,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5854,6 +7862,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -5897,6 +7913,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5939,6 +7963,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -5981,6 +8013,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6022,6 +8062,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -6065,6 +8113,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6107,6 +8163,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6149,6 +8213,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6190,6 +8262,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -6233,6 +8313,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6275,6 +8363,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6317,6 +8413,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6358,6 +8462,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -6401,6 +8513,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6443,6 +8563,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6485,6 +8613,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6526,6 +8662,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -6569,6 +8713,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6611,6 +8763,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6653,6 +8813,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6694,6 +8862,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -6737,6 +8913,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6779,6 +8963,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6821,6 +9013,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6862,6 +9062,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -6905,6 +9113,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6947,6 +9163,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -6989,6 +9213,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -7030,6 +9262,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -7073,6 +9313,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -7115,6 +9363,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -7157,6 +9413,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -7198,6 +9462,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -7241,6 +9513,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -7283,6 +9563,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -7325,6 +9613,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -7366,6 +9662,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -7409,6 +9713,14 @@
                 ],
                 "conditions": [
                   {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
+                  {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
                       "^com\\.apple\\.Terminal$",
@@ -7450,6 +9762,14 @@
                   }
                 ],
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -7491,6 +9811,14 @@
                   "basic.to_if_held_down_threshold_milliseconds": 200
                 },
                 "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  },
                   {
                     "type": "frontmost_application_unless",
                     "bundle_identifiers": [
@@ -7539,7 +9867,17 @@
                 ],
                 "parameters": {
                   "basic.to_if_held_down_threshold_milliseconds": 100
-                }
+                },
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "type": "basic",
@@ -7569,7 +9907,17 @@
                 ],
                 "parameters": {
                   "basic.to_if_held_down_threshold_milliseconds": 100
-                }
+                },
+                "conditions": [
+                  {
+                    "type": "device_if",
+                    "identifiers": [
+                      {
+                        "is_built_in_keyboard": true
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           }

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -1,5 +1,6 @@
 import {
   ifApp,
+  ifDevice,
   map,
   mapSimultaneous,
   rule,
@@ -9,6 +10,10 @@ import {
 import { TERMINAL_BUNDLE_IDS } from './apps.ts';
 
 const ifTerminal = ifApp({ bundle_identifiers: [...TERMINAL_BUNDLE_IDS] });
+
+// 外付けキーボード (7sPro) はキーマップを QMK 側で完結させるため、Karabiner の
+// ルールは内蔵キーボードだけに適用する。rule を追加するときも必ず付ける。
+const ifBuiltIn = ifDevice({ is_built_in_keyboard: true });
 
 // vim hjkl key repeat conflicts fundamentally with hold-for-modifier. Only the
 // right-index J needs disabling in vim apps (vim/Vimium hold j to scroll); F
@@ -81,7 +86,11 @@ function homeRowMod(opts: {
 const SIMPLE_MODIFICATIONS = [map('caps_lock').to('left_control')];
 
 writeToProfile('Default profile', [
-  rule('Terminal Ctrl tap-hold + tmux IME bypass', ifTerminal).manipulators([
+  rule(
+    'Terminal Ctrl tap-hold + tmux IME bypass',
+    ifBuiltIn,
+    ifTerminal,
+  ).manipulators([
     map({ key_code: 'left_control', modifiers: { optional: ['any'] } })
       .to({ key_code: 'left_control', lazy: true })
       .toIfAlone({ key_code: 'left_control', hold_down_milliseconds: 300 })
@@ -95,7 +104,7 @@ writeToProfile('Default profile', [
       .to({ key_code: 'spacebar', modifiers: ['left_control'] }),
   ]),
 
-  rule('Ctrl navigation (hjkl / word)').manipulators([
+  rule('Ctrl navigation (hjkl / word)', ifBuiltIn).manipulators([
     map({
       key_code: 'comma',
       modifiers: { mandatory: ['left_control'], optional: ['any'] },
@@ -121,7 +130,7 @@ writeToProfile('Default profile', [
 
   // Shift を含めると macOS の中国語変換サービス (⌃⌥⇧⌘C / ⌃⌥⇧⌘V) と衝突するため
   // ⌘⌥⌃ に留める。Cmd を含むことが Secure Input 固着時のホットキー生存条件。
-  rule('Home Row Mods (Cmd+Opt+Ctrl on ;)').manipulators([
+  rule('Home Row Mods (Cmd+Opt+Ctrl on ;)', ifBuiltIn).manipulators([
     map({ key_code: 'semicolon', modifiers: { optional: ['any'] } })
       .to({
         key_code: 'right_command',
@@ -135,7 +144,10 @@ writeToProfile('Default profile', [
       }),
   ]),
 
-  rule('Home Row Mods (Shift on F, Opt on S, Ctrl on D)').manipulators([
+  rule(
+    'Home Row Mods (Shift on F, Opt on S, Ctrl on D)',
+    ifBuiltIn,
+  ).manipulators([
     ...homeRowMod({
       key: 'f',
       toModifier: { key_code: 'left_shift' },
@@ -153,7 +165,7 @@ writeToProfile('Default profile', [
     }),
   ]),
 
-  rule('Home Row Mods (Shift on J)', unlessVimApp).manipulators([
+  rule('Home Row Mods (Shift on J)', ifBuiltIn, unlessVimApp).manipulators([
     ...homeRowMod({
       key: 'j',
       toModifier: { key_code: 'right_shift' },
@@ -161,7 +173,7 @@ writeToProfile('Default profile', [
     }),
   ]),
 
-  rule('Tap CMD to toggle Kana/Eisuu').manipulators([
+  rule('Tap CMD to toggle Kana/Eisuu', ifBuiltIn).manipulators([
     withMapper({
       left_command: 'japanese_eisuu',
       right_command: 'japanese_kana',


### PR DESCRIPTION
## Background / 背景

メインキーボードを 7sPro に移行する予定で、キーマップは QMK の書き込みで実現する。Karabiner のルールが外付けキーボードにも効いたままだと、QMK 側のマップと二重に適用されて競合する。

## Changes / 変更内容

`karabiner.ts` に `ifBuiltIn = ifDevice({ is_built_in_keyboard: true })` を追加し、complex rule 全 6 件（Terminal Ctrl tap-hold / Ctrl navigation / HRM 3 件 / Cmd tap → IME）の条件に付与した。生成される全 247 manipulator に `device_if` が入る。

`README.md` / `HRM.md` に適用範囲を追記。simple modification (`caps_lock` → `left_control`) は Karabiner のスキーマ上デバイス条件を持てないため対象外で、外付け側は QMK で `KC_CAPS` を使わない運用で回避する旨も記載した。

## Impact scope / 影響範囲

- 内蔵キーボード: 挙動は変わらない
- 外付けキーボード: Karabiner の complex modifications が一切効かなくなる（simple modification の `caps_lock` → `left_control` のみ残る）

## Testing / 動作確認

- [x] `bun run build` 実行 → 実機に適用済み。`~/.config/karabiner/karabiner.json` の 247/247 manipulator に `device_if: [{is_built_in_keyboard: true}]` が入り、`core_service.log` に `invalid shared secret` なし
- [x] 生成 JSON から `device_if` のみを機械的に除去すると変更前の `karabiner.json` と完全一致（条件追加以外の差分ゼロ）
- [x] CI と同じ生成経路（`HOME` を隔離して `karabiner.ts` を実行）でリポジトリのコピーを再生成し、`tests/karabiner.bats` の同期チェックが通る状態を確認
- [ ] 内蔵キーボードで HRM（F/S/D/J/;）・Ctrl+hjkl・tmux prefix（Ctrl+Space）・Cmd tap の IME 切り替えが従来どおり動作（実キー入力での確認は未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
