### PR TITLE
feat(qmk): add home row mods and Cmd-tap IME switching to 7sPro

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -4,6 +4,8 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 
 適用対象は **Mac 内蔵キーボードのみ** (`ifBuiltIn` = `device_if: is_built_in_keyboard`)。外付けキーボード (7sPro) は QMK 側でキーマップを完結させるため Karabiner を通さない。以下の Scope 列の「All apps」は内蔵キーボード上での話。
 
+7sPro 側にも同じ HRM を実装済み (`.config/qmk/README.md`)。**差は J だけ** — QMK はホストのアプリを知らないため「vim 系アプリで無効」を再現できず、7sPro では J に HRM を載せていない。ターミナル限定の Ctrl tap-hold と Ctrl+Space も同じ理由で 7sPro 側は未対応。
+
 ## Modifier mappings
 
 | Key             | Hold → Modifier | Scope                                 |

--- a/.config/qmk/README.md
+++ b/.config/qmk/README.md
@@ -21,6 +21,39 @@ mise run qmk   # toolchain + qmk_firmware clone + overlay_dir 登録
 | `~/.local/bin/qmk` | CLI (uv tool 経由) |
 | `~/Library/Application Support/qmk/qmk.ini` | CLI 設定 (`user.qmk_home` / `user.overlay_dir`) |
 
+## キーマップ
+
+MacBook 内蔵キーボードでは Karabiner が同等の機能を提供している (`../karabiner/HRM.md`)。持ち替えたときの操作感を揃えるため、同じものを QMK 側に実装している。
+
+### Home Row Mods
+
+| キー | ホールド |
+|---|---|
+| F | Shift |
+| S | Option |
+| D | Control |
+| ; | ⌘⌥⌃ (Raycast 用) |
+
+`A` には載せない (左手首腱鞘炎対策)。`J` にも載せない — Karabiner 側は vim 系アプリで無効化しているが、**QMK はホストのアプリを知らないため同じ切り分けができない**。7sPro では右 Shift は物理キーを使う。
+
+`CHORDAL_HOLD` が同手のロールをタップ扱いにするので、`fa` のような同手ロールで Shift が誤爆しない。**ただし効くのは `TAPPING_TERM` (180ms) 以内**で、意図的に同手で修飾子を使いたいときは長めにホールドしてから相方を叩く (Karabiner 側も同じ運用)。加えて `FLOW_TAP_TERM` が高速タイプ中のホールド判定を止める。
+
+### Cmd 単押しで IME
+
+左 Cmd = 英数 (`KC_LNG2`)、右 Cmd = かな (`KC_LNG1`)。Karabiner の `japanese_eisuu` / `japanese_kana` と同一の HID usage。
+
+`get_hold_on_other_key_press()` で Cmd だけ「他キー押下で即ホールド確定」にしている。`TAPPING_TERM` を待つと `Cmd+C` が鈍く感じるため。
+
+### 最下段
+
+```
+[Alt][Cmd/英数][Space][MO(FN)] │ [Space][Enter][Cmd/かな][Alt]
+                      ^^^^^^^^   ^^^^^^^
+                   左親指ホーム  右親指ホーム
+```
+
+右親指の Space は tmux prefix (`D` ホールド + Space = Ctrl+Space) の相方なので動かさない。MacBook では同じ位置が Space なので、左親指ホームだけは 2 台で役割が違う (レイヤーキーを最も押しやすい位置に置くことを優先した)。
+
 ## Build & Flash
 
 ```bash
@@ -38,7 +71,7 @@ ATmega32U4 なので UF2 のドラッグ&ドロップではなく avrdude 書き
 
 キーマップから入れる。物理リセットは不要。
 
-1. `MO(_FN)` を押しながら — 最下段の 1 つ上、右端のキー
+1. `MO(_FN)` を押しながら — 左親指ホーム、または最下段の 1 つ上の右端
 2. **左上 Esc の位置**を押す — `_FN` レイヤーの `TG(_ADJUST)` に当たる
 3. `MO(_FN)` を離す
 4. **右上 Grave (`~`) の位置**を押す — `_ADJUST` レイヤーの `QK_BOOT`
@@ -75,9 +108,18 @@ QMK CLI の設定は `~/.config/qmk/` ではなく `~/Library/Application Suppor
 
 ## Karabiner との責務分割
 
-Complex modifications は `ifBuiltIn` で内蔵キーボードに限定してあるので、7sPro には効かない。Home Row Mods を 7sPro でも使うなら QMK 側に実装する。
+Complex modifications は `ifBuiltIn` で内蔵キーボードに限定してあるので、7sPro には効かない。HRM と IME 切替は上記のとおり QMK 側で実装済み。
 
 Simple Modifications (`caps_lock` → `left_control`) だけは profile 全体に効くが、このキーマップは caps lock を送らず該当位置に直接 `KC_LCTL` を置いているので衝突しない。詳細は `../karabiner/README.md`。
+
+### QMK では実現できないもの
+
+アプリごとに挙動を変える必要があるものは、QMK にホストのアプリを知る手段がないため移植できない:
+
+- ターミナルでの Ctrl tap-hold
+- ターミナルでの Ctrl+Space → 英数 (tmux prefix と同時に IME を抜ける)
+
+これらを 7sPro でも使いたい場合は Karabiner 側のルールに 7sPro のデバイス条件を足すことになる (未対応)。
 
 ## VIA / Remap
 

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/config.h
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/config.h
@@ -20,3 +20,10 @@
 
 #define QUICK_TAP_TERM 0
 #define TAPPING_TERM 180
+
+/* Home Row Mods. CHORDAL_HOLD settles same-hand chords as taps, so only
+ * opposite-hand chords produce a modifier; it requires PERMISSIVE_HOLD or
+ * HOLD_ON_OTHER_KEY_PRESS to define the opposite-hand case. */
+#define CHORDAL_HOLD
+#define PERMISSIVE_HOLD
+#define FLOW_TAP_TERM 150

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
@@ -25,11 +25,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------+--------+--------|
        KC_TAB,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P, KC_LBRC, KC_RBRC, KC_BSPC,
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------+--------|
-      KC_LCTL,    KC_A,    KC_S,    KC_D,    KC_F,    KC_G,        KC_H,    KC_J,    KC_K,    KC_L, KC_SCLN, KC_QUOT,  KC_ENT,
+      KC_LCTL,    KC_A, LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), KC_G,  KC_H,    KC_J,    KC_K,    KC_L, RCAG_T(KC_SCLN), KC_QUOT, KC_ENT,
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
       KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT, MO(_FN),
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
-               KC_LALT, KC_LGUI,  KC_SPC,  KC_SPC,               KC_SPC,  KC_SPC,          KC_RGUI, KC_RALT
+               KC_LALT, LGUI_T(KC_LNG2),  KC_SPC,  MO(_FN),      KC_SPC,  KC_ENT,   RGUI_T(KC_LNG1), KC_RALT
           //`---------------------------------------------|   |--------------------------------------------'
   ),
 
@@ -62,6 +62,30 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   )
 };
 
+
+// '*' exempts a key from Chordal Hold's opposite-hands rule. The Cmd mod-taps
+// need same-hand chords (Cmd+A, Cmd+C) and ; sends ⌘⌥⌃ to Raycast, whose
+// hotkey may sit on the right hand. Marking them 'L'/'R' would settle those as
+// taps and emit 英数 / かな / ; instead of the modifier.
+const char chordal_hold_layout[MATRIX_ROWS][MATRIX_COLS] PROGMEM = LAYOUT(
+  'L','L','L','L','L','L',    'R','R','R','R','R','R','R','R','R',
+  'L','L','L','L','L','L',    'R','R','R','R','R','R','R','R',
+  'L','L','L','L','L','L',    'R','R','R','R','*','R','R',
+  'L','L','L','L','L','L',    'R','R','R','R','R','R','R',
+      'L','*','L','L',        'R','R','*','R'
+);
+
+// Cmd has to engage the moment another key is pressed; waiting out TAPPING_TERM
+// would make Cmd+C feel sluggish. The home row mods stay on PERMISSIVE_HOLD.
+bool get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record) {
+  switch (keycode) {
+    case LGUI_T(KC_LNG2):
+    case RGUI_T(KC_LNG1):
+      return true;
+    default:
+      return false;
+  }
+}
 
 //A description for expressing the layer position in LED mode.
 layer_state_t layer_state_set_user(layer_state_t state) {


### PR DESCRIPTION
## Background / 背景

7sPro のキーマップは QMK 管理下に入ったが中身は default 相当のままで、MacBook 内蔵キーボード（Karabiner が HRM・IME 切替を提供）と操作感が大きく違っていた。ハイブリッド出社で MacBook 単体を使う機会が一定あるため、この差はそのままストレスになる。

7sPro 側にも同じ機能を実装する。

## Changes / 変更内容

**Home Row Mods**

`F`=Shift / `S`=Option / `D`=Control / `;`=⌘⌥⌃。`A` には載せない（左手首腱鞘炎対策）。`J` にも載せない — Karabiner 側は vim 系アプリで無効化しているが、QMK はホストのアプリを知らないため同じ切り分けができない。

`CHORDAL_HOLD` + `PERMISSIVE_HOLD` + `FLOW_TAP_TERM 150` を有効化した。`karabiner.ts` は bilateral combinations が無いのを `mapSimultaneous` で 900 個以上のルールを生成して回避しているが、QMK には組み込みで入っているため `config.h` の 3 行で済む。

`chordal_hold_layout` で手を宣言し、左右の Cmd と `;` は `'*'`（同手ルールの対象外）にした。`'L'`/`'R'` のままだと `Cmd+A` や `Cmd+C` が同手扱いでタップに落ち、英数/かなが出てしまう。

**Cmd 単押しで IME 切替**

左 Cmd = 英数（`KC_LNG2`）、右 Cmd = かな（`KC_LNG1`）。Karabiner の `japanese_eisuu` / `japanese_kana` と同一の HID usage。`get_hold_on_other_key_press()` で Cmd だけ「他キー押下で即ホールド確定」にしている（`TAPPING_TERM` を待つと `Cmd+C` が鈍い）。

**最下段**

```
[Alt][Cmd/英数][Space][MO(FN)] │ [Space][Enter][Cmd/かな][Alt]
                      ^^^^^^^^   ^^^^^^^
                   左親指ホーム  右親指ホーム
```

レイヤーキーを左親指ホームに移し、余っていた Space を Enter に置き換えた。右親指の Space は tmux prefix の相方なので動かしていない。

## Impact scope / 影響範囲

- フラッシュ 22,648 / 28,672 バイト（79%、残り 6,024）
- 左親指ホームは MacBook では Space なので、2 台で役割が違う唯一の箇所（レイヤーキーを最も押しやすい位置に置くことを優先した）
- ターミナル限定の Ctrl tap-hold と Ctrl+Space → 英数 は QMK では実現できないため 7sPro 側は未対応。`.config/qmk/README.md` と `HRM.md` に明記した

## Testing / 動作確認

- [x] `bats tests` 26/26 pass
- [x] `qmk userspace-compile` が通る
- [x] 左右両方の Pro Micro に書き込み、verify 通過
- [x] `F`/`S`/`D` の単押しで `f`/`s`/`d`、逆手チョードで修飾子が成立
- [x] 同手ロール（`sad` / `fed`）で修飾子が誤爆しない
- [x] `F` を `TAPPING_TERM` 超で長押し → 同手でも大文字になる（意図的な同手修飾子）
- [x] 左 Cmd 単押しで英数、右 Cmd 単押しでかな、`Cmd+C` / `Cmd+A` も動作
- [x] `;` 単押しで `;`、ホールド + ホットキーで Raycast 起動
- [x] 左親指 `MO(_FN)` + 数字段で F1〜F12、右手 2u キーで Enter
- [x] `D` ホールド + 右親指 Space で tmux prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)