### PR TITLE
feat(qmk): rebuild the 7sPro bottom row around Cmd

### DIFF
--- a/.config/qmk/README.md
+++ b/.config/qmk/README.md
@@ -47,12 +47,19 @@ MacBook 内蔵キーボードでは Karabiner が同等の機能を提供して�
 ### 最下段
 
 ```
-[Alt][Cmd/英数][Space][MO(FN)] │ [Space][Enter][Cmd/かな][Alt]
-                      ^^^^^^^^   ^^^^^^^
-                   左親指ホーム  右親指ホーム
+[MO(FN)][ Ctrl ][ Alt  ][Cmd/英数] │ [Space][ Cmd/かな ][ BS  ][Return]
+  1u      1.5u    1.5u    1.25u       1.25u     2u        1.5u    1u
+                         ^^^^^^^^      ^^^^^^^
+                      左親指ホーム    右親指ホーム
 ```
 
-右親指の Space は tmux prefix (`D` ホールド + Space = Ctrl+Space) の相方なので動かさない。MacBook では同じ位置が Space なので、左親指ホームだけは 2 台で役割が違う (レイヤーキーを最も押しやすい位置に置くことを優先した)。
+**左手は MacBook の `cmd` から左をそのまま並べている** (`fn` `ctrl` `opt` `cmd`)。Cmd が最頻出かつ IME 切替も兼ねるので、MacBook と同じ「親指の定位置のすぐ内側」に置くことを最優先した。`fn` は Apple 独自実装で QMK から送れないため、その枠を `MO(_FN)` に充てている。
+
+Home Row Mods のリファレンス実装 ([Miryoku](https://github.com/manna-harbour/miryoku)) は GUI を小指 (`A`) に載せる (GACS) ので最下段の Cmd を議論しない。ここでは `A` に HRM を載せない方針 (左手首腱鞘炎対策) を優先した結果、Cmd を物理キーとして親指に置く必要がある。
+
+Space は右親指のみ。左手側は修飾キーで埋まるが、実際に Space を打つのは右親指だけなので支障はない (左手が Ctrl / D / Cmd と組む側だから)。tmux prefix (`D` ホールド + Space = Ctrl+Space) もこの位置で成立する。
+
+BS と Return を親指に置いたのは、素の配置では BS が右上・Return が右手小指 (2.25u) で遠いため。`[9,3]` `[9,4]` は親指ホームから 2〜3 つ外側なので、指を伸ばす必要はある。
 
 ## Build & Flash
 

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
@@ -29,7 +29,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
       KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT, MO(_FN),
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
-               KC_LALT, LGUI_T(KC_LNG2),  KC_SPC,  MO(_FN),      KC_SPC,  KC_ENT,   RGUI_T(KC_LNG1), KC_RALT
+               MO(_FN), KC_LCTL, KC_LALT, LGUI_T(KC_LNG2),   KC_SPC, RGUI_T(KC_LNG1), KC_BSPC,  KC_ENT
           //`---------------------------------------------|   |--------------------------------------------'
   ),
 
@@ -72,7 +72,7 @@ const char chordal_hold_layout[MATRIX_ROWS][MATRIX_COLS] PROGMEM = LAYOUT(
   'L','L','L','L','L','L',    'R','R','R','R','R','R','R','R',
   'L','L','L','L','L','L',    'R','R','R','R','*','R','R',
   'L','L','L','L','L','L',    'R','R','R','R','R','R','R',
-      'L','*','L','L',        'R','R','*','R'
+      'L','L','L','*',        'R','*','R','R'
 );
 
 // Cmd has to engage the moment another key is pressed; waiting out TAPPING_TERM


### PR DESCRIPTION
## Background / 背景

#205 の最下段が実用に耐えなかった。左親指ホームを `MO(_FN)` にしたため、MacBook で Space を打つ位置がレイヤーキーになり、まともにタイプできない状態だった。

より本質的な問題は **Cmd の位置**。Cmd は最頻出キーで、かつ単押しで IME 切替も兼ねているのに、MacBook では「親指の定位置のすぐ隣」なのに対し 7sPro では 2 つ外側にあった。

加えて素の配置では BS が右上、Return が右手小指 (2.25u) で遠く、押しづらかった。

Home Row Mods のリファレンス実装 ([Miryoku](https://github.com/manna-harbour/miryoku)) は GUI を小指 (`A`) に載せる (GACS) ため最下段の Cmd を議論しないが、ここでは `A` に HRM を載せない方針（左手首腱鞘炎対策）を優先しているので、Cmd を物理キーとして親指に置く必要がある。

## Changes / 変更内容

```
[MO(FN)][ Ctrl ][ Alt ][Cmd/英数] │ [Space][ Cmd/かな ][ BS ][Return]
  1u      1.5u   1.5u   1.25u       1.25u     2u        1.5u   1u
                       ^^^^^^^^^     ^^^^^^^
                    左親指ホーム    右親指ホーム
```

- **左手は MacBook の `cmd` から左をそのまま並べた**（`fn` `ctrl` `opt` `cmd`）。`fn` は Apple 独自実装で QMK から送れないため、その枠を `MO(_FN)` に充てた
- **右手は Space / Cmd / BS / Return**。BS を Return より内側にしたのは打鍵頻度から
- `chordal_hold_layout` の `'*'` を Cmd の新しい位置（`[4,4]` と `[9,1]`）へ移した。`Cmd+A` `Cmd+C` のような同手チョードが必要なため

## Impact scope / 影響範囲

- **Space は右親指のみ**になった。左手側は修飾キーで埋まるが、Ctrl / D / Cmd と組むのは左手なので実際に Space を打つのは右親指だけであり支障はない
- **右 option が無くなった**。左 Alt と HRM の `S`=Option でカバーできる
- tmux prefix (`D` ホールド + 右親指 Space) はこの配置でも成立する
- フラッシュサイズは変わらず 22,648 / 28,672（79%）

## Testing / 動作確認

- [x] `bats tests` 26/26 pass
- [x] `qmk userspace-compile` が通る
- [x] 左右両方の Pro Micro に書き込み、verify 通過
- [x] 左親指ホームのタップで英数、ホールド + `C` / `A` でコピー・全選択（`'*'` handedness の移動を確認）
- [x] 右の 2u キーのタップでかな、ホールドで Cmd
- [x] 右親指を伸ばして BS / Return に届く
- [x] Cmd の位置が MacBook と同じ感覚になったことを実機で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)