### PR TITLE
feat(qmk): mirror Karabiner's Ctrl navigation on the 7sPro

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -28,6 +28,8 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 
 ## Ctrl navigation (D ホールドで発火)
 
+hjkl / , / . の変換は 7sPro 側にも実装済み (`.config/qmk/README.md`)。Ctrl+Space (terminal) だけはアプリ判定が必要なため内蔵キーボード限定。
+
 | Combo                     | Action                                       |
 | ------------------------- | -------------------------------------------- |
 | Ctrl + h / j / k / l      | ← / ↓ / ↑ / →                                |

--- a/.config/nvim/lua/config/keymaps.lua
+++ b/.config/nvim/lua/config/keymaps.lua
@@ -4,11 +4,8 @@ local map = vim.keymap.set
 
 map('n', '<Esc>', '<cmd>nohlsearch<CR>', { desc = 'Clear search highlight' })
 
--- Window navigation
-map('n', '<C-h>', '<C-w>h', { desc = 'Window left' })
-map('n', '<C-j>', '<C-w>j', { desc = 'Window down' })
-map('n', '<C-k>', '<C-w>k', { desc = 'Window up' })
-map('n', '<C-l>', '<C-w>l', { desc = 'Window right' })
+-- Ctrl+hjkl は Karabiner (内蔵キーボード) と QMK (7sPro) が矢印に変換するため
+-- ここに割り当てても届かない。ウィンドウ移動は <C-w>hjkl を直接使う。
 
 -- Center cursor on big jumps / search
 map('n', '<C-d>', '<C-d>zz', { desc = 'Half page down (centered)' })

--- a/.config/qmk/README.md
+++ b/.config/qmk/README.md
@@ -44,6 +44,19 @@ MacBook 内蔵キーボードでは Karabiner が同等の機能を提供して�
 
 `get_hold_on_other_key_press()` で Cmd だけ「他キー押下で即ホールド確定」にしている。`TAPPING_TERM` を待つと `Cmd+C` が鈍く感じるため。
 
+### Ctrl ナビゲーション
+
+| 入力 | 出力 |
+|---|---|
+| Ctrl + h / j / k / l | ← / ↓ / ↑ / → |
+| Ctrl + , / . | Opt + ← / → (word jump) |
+
+`process_record_user()` の `ctrl_nav()` で実装。Ctrl のビットだけ落として送るので、`Ctrl+Shift+h` は `Shift+←` になり選択範囲が伸びる。
+
+Ctrl の出どころは `D` のホールド (HRM)、`A` の左、最下段の左から 2 番目のいずれでもよい。
+
+`Ctrl+h/j/k/l` を潰すので **nvim のウィンドウ移動 (`<C-w>hjkl` の別名) は使えない**。内蔵キーボードでも Karabiner が同じ変換をしていて元から機能していなかったため、`.config/nvim/lua/config/keymaps.lua` から該当の割り当てを外した。
+
 ### 最下段
 
 ```

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
@@ -106,6 +106,38 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 return state;
 }
 
+// Ctrl + hjkl / , / . → arrows and word jump, mirroring the Karabiner rule that
+// covers the built-in keyboard. The Ctrl bit is stripped so the app sees a bare
+// arrow; any other modifier held at the time (Shift, for selection) passes
+// through. Returns true when the key was replaced.
+static bool ctrl_nav(uint16_t keycode, keyrecord_t *record) {
+  if (!(get_mods() & MOD_MASK_CTRL)) {
+    return false;
+  }
+  if (!record->event.pressed) {
+    return true;  // the press already sent a complete tap
+  }
+
+  uint16_t to_code;
+  switch (keycode) {
+    case KC_H:    to_code = KC_LEFT;        break;
+    case KC_J:    to_code = KC_DOWN;        break;
+    case KC_K:    to_code = KC_UP;          break;
+    case KC_L:    to_code = KC_RIGHT;       break;
+    case KC_COMM: to_code = LALT(KC_LEFT);  break;
+    case KC_DOT:  to_code = LALT(KC_RIGHT); break;
+    default:      return false;
+  }
+
+  const uint8_t saved = get_mods();
+  del_mods(MOD_MASK_CTRL);
+  send_keyboard_report();
+  tap_code16(to_code);
+  set_mods(saved);
+  send_keyboard_report();
+  return true;
+}
+
 int RGB_current_mode;
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   bool result = false;
@@ -126,6 +158,14 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
           }
         break;
     #endif
+    case KC_H:
+    case KC_J:
+    case KC_K:
+    case KC_L:
+    case KC_COMM:
+    case KC_DOT:
+      result = !ctrl_nav(keycode, record);
+      break;
     default:
       result = true;
       break;


### PR DESCRIPTION
## Background / 背景

`Ctrl+hjkl` → 矢印、`Ctrl+,.` → word jump は Karabiner が内蔵キーボードで提供しているが、7sPro には無かった。持ち替えるたびにカーソル移動の手が変わるため揃える。

調べる過程で既存の矛盾が見つかった。`.config/nvim/lua/config/keymaps.lua` に `<C-h>` 〜 `<C-l>` をウィンドウ移動に割り当てていたが、**内蔵キーボードでは Karabiner が矢印に変換するため元から発火していなかった**。7sPro だけこの nvim キーマップが生きていて、それが「Ctrl ナビゲーションは既に動いている」という誤解を生んでいた。

## Changes / 変更内容

- `keymap.c` に `ctrl_nav()` を追加。`process_record_user()` から `h/j/k/l/,/.` を拾い、Ctrl のビットだけ落として矢印（または `Opt+←/→`）を送る
  - Ctrl 以外の修飾子は保持するので `Ctrl+Shift+h` は `Shift+←` になり選択範囲が伸びる
  - Ctrl の出どころは `D` のホールド（HRM）でも物理 Ctrl でもよい
- `keymaps.lua` からウィンドウ移動の 4 行を削除。届かない割り当てが残っていた矛盾を解消し、理由をコメントで残した
- `.config/qmk/README.md` と `HRM.md` に対応関係を追記

## Impact scope / 影響範囲

- **nvim のウィンドウ移動は `<C-w>hjkl` を直接使うことになる**。内蔵キーボードでは元から `<C-h>` 系が機能していなかったので、実際の操作は変わらない
- `Ctrl+h` は macOS ネイティブでは BS だが、内蔵キーボードでは Karabiner が既に潰しているため挙動は揃う方向
- フラッシュ 22,880 / 28,672（79.8%、+232 バイト）

## Testing / 動作確認

- [x] `bats tests` 26/26 pass
- [x] `qmk userspace-compile` が通る
- [x] 左右両方の Pro Micro に書き込み、verify 通過
- [x] `Ctrl+h/j/k/l` で ←↓↑→（`D` ホールド経由でも動作。mod-tap の確定タイミングが問題にならないことを確認）
- [x] `Ctrl+,` / `Ctrl+.` で単語単位の移動
- [x] `Ctrl+Shift+h` で選択範囲が伸びる（Ctrl だけ落とす実装の確認）
- [x] nvim で `Ctrl+j`/`k` がカーソル移動になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)