### PR TITLE
feat(qmk): drop out of the IME on the tmux prefix

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -4,7 +4,10 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 
 適用対象は **Mac 内蔵キーボードのみ** (`ifBuiltIn` = `device_if: is_built_in_keyboard`)。外付けキーボード (7sPro) は QMK 側でキーマップを完結させるため Karabiner を通さない。以下の Scope 列の「All apps」は内蔵キーボード上での話。
 
-7sPro 側にも同じ HRM を実装済み (`.config/qmk/README.md`)。**差は J だけ** — QMK はホストのアプリを知らないため「vim 系アプリで無効」を再現できず、7sPro では J に HRM を載せていない。ターミナル限定の Ctrl tap-hold と Ctrl+Space も同じ理由で 7sPro 側は未対応。
+7sPro 側にも同じ HRM・IME 切替・Ctrl ナビゲーションを実装済み (`.config/qmk/README.md`)。**残る差は 2 つだけ**:
+
+- **J = Shift** — QMK はホストのアプリを知らないため「vim 系アプリで無効」を再現できず、7sPro では載せていない
+- **ターミナルの Ctrl tap-hold** — prefix が `Ctrl+b` だった時代の対策 (#69) で前提が失われているため、意図的に移していない
 
 ## Modifier mappings
 
@@ -28,7 +31,7 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 
 ## Ctrl navigation (D ホールドで発火)
 
-hjkl / , / . の変換は 7sPro 側にも実装済み (`.config/qmk/README.md`)。Ctrl+Space (terminal) だけはアプリ判定が必要なため内蔵キーボード限定。
+hjkl / , / . の変換と Ctrl+Space の IME 抜けは 7sPro 側にも実装済み (`.config/qmk/README.md`)。ただし QMK はアプリ判定ができないため、7sPro の Ctrl+Space は全アプリ対象。
 
 | Combo                     | Action                                       |
 | ------------------------- | -------------------------------------------- |

--- a/.config/qmk/README.md
+++ b/.config/qmk/README.md
@@ -57,6 +57,12 @@ Ctrl の出どころは `D` のホールド (HRM)、`A` の左、最下段の左
 
 `Ctrl+h/j/k/l` を潰すので **nvim のウィンドウ移動 (`<C-w>hjkl` の別名) は使えない**。内蔵キーボードでも Karabiner が同じ変換をしていて元から機能していなかったため、`.config/nvim/lua/config/keymaps.lua` から該当の割り当てを外した。
 
+### tmux prefix と IME
+
+`Ctrl+Space` (`D` ホールド + 右親指 Space) は、先に 英数 (`KC_LNG2`) を送ってから `Ctrl+Space` を送る。日本語入力中でも prefix を打つだけで IME から抜けられる。
+
+Karabiner 側はこれをターミナル限定にしているが、QMK はフロントのアプリを判定できないため **全アプリ対象**。`Ctrl+Space` に他の割り当てが無いので支障はない (macOS 自身の入力ソース切替は `settings.sh` で無効化済み)。
+
 ### 最下段
 
 ```
@@ -132,14 +138,10 @@ Complex modifications は `ifBuiltIn` で内蔵キーボードに限定してあ
 
 Simple Modifications (`caps_lock` → `left_control`) だけは profile 全体に効くが、このキーマップは caps lock を送らず該当位置に直接 `KC_LCTL` を置いているので衝突しない。詳細は `../karabiner/README.md`。
 
-### QMK では実現できないもの
+### 移していないもの
 
-アプリごとに挙動を変える必要があるものは、QMK にホストのアプリを知る手段がないため移植できない:
-
-- ターミナルでの Ctrl tap-hold
-- ターミナルでの Ctrl+Space → 英数 (tmux prefix と同時に IME を抜ける)
-
-これらを 7sPro でも使いたい場合は Karabiner 側のルールに 7sPro のデバイス条件を足すことになる (未対応)。
+- **`J` = Shift**。Karabiner 側は vim 系アプリで無効化しているが、QMK はホストのアプリを知らないため同じ切り分けができない。7sPro では右 Shift は物理キーを使う
+- **ターミナルでの Ctrl tap-hold**。[PR #69](https://github.com/HagaSpa/dotfiles/pull/69) で「`Ctrl+b` を素早くタップして離した後に `b` を押すと単独の `b` になる」対策として入ったものだが、**tmux prefix はその後 `Ctrl+Space` に変わっており前提が失われている**。さらに `LCTL_T(KC_D)` が送る `left_control` を Karabiner が再度掴む二重処理のリスクがあるため、意図的に移していない
 
 ## VIA / Remap
 

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
@@ -138,6 +138,29 @@ static bool ctrl_nav(uint16_t keycode, keyrecord_t *record) {
   return true;
 }
 
+// Ctrl+Space (tmux prefix) drops out of the IME on the way through: 英数 first,
+// then the prefix itself. The Karabiner equivalent scopes this to terminals, but
+// QMK cannot see the frontmost app so it applies everywhere. That is safe as long
+// as nothing else is bound to Ctrl+Space — settings.sh disables macOS's own
+// input-source switcher on it.
+static bool ctrl_space_ime_bypass(keyrecord_t *record) {
+  if (!(get_mods() & MOD_MASK_CTRL)) {
+    return false;
+  }
+  if (!record->event.pressed) {
+    return true;
+  }
+
+  const uint8_t saved = get_mods();
+  del_mods(MOD_MASK_CTRL);
+  send_keyboard_report();
+  tap_code(KC_LNG2);
+  set_mods(saved);
+  send_keyboard_report();
+  tap_code(KC_SPC);
+  return true;
+}
+
 int RGB_current_mode;
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
   bool result = false;
@@ -165,6 +188,9 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     case KC_COMM:
     case KC_DOT:
       result = !ctrl_nav(keycode, record);
+      break;
+    case KC_SPC:
+      result = !ctrl_space_ime_bypass(record);
       break;
     default:
       result = true;


### PR DESCRIPTION
## Background / 背景

日本語入力中に tmux を操作するとき、prefix を押すだけで IME から抜けられる機能を Karabiner が内蔵キーボードに提供している。7sPro には無かったため揃える。

当初の計画では「アプリ判定が必要なので Karabiner 側に 7sPro のデバイス条件を足す」としていたが、**`Ctrl+Space` に他の割り当てが無いためターミナル限定にする必要がなく、QMK で実装できると分かった**。これにより #202 の「外付けは Karabiner を通さない」原則を維持できる。

## Changes / 変更内容

`keymap.c` に `ctrl_space_ime_bypass()` を追加。`Ctrl+Space` を検出したら、Ctrl を外して 英数 (`KC_LNG2`) を送り、Ctrl を戻して `Ctrl+Space` を送る。

Karabiner 版はターミナル限定だが、QMK はフロントのアプリを判定できないため全アプリ対象。macOS 自身の `Ctrl+Space`（入力ソース切替）は `settings.sh` で無効化済みなので衝突しない。

あわせて、**ターミナルの Ctrl tap-hold を移さない判断**を README に記録した。[PR #69](https://github.com/HagaSpa/dotfiles/pull/69) で「`Ctrl+b` を素早くタップして離した後に `b` を押すと単独の `b` になる」対策として入ったものだが、tmux prefix はその後 `Ctrl+Space` に変わっており前提が失われている。加えて `LCTL_T(KC_D)` が送る `left_control` を Karabiner が再度掴む二重処理のリスクがある。

## Impact scope / 影響範囲

- **ターミナル以外でも `Ctrl+Space` で英数に切り替わる**。他に `Ctrl+Space` を使う場面が無いことを実機で確認済み
- これで MacBook との差は `J`=Shift と Ctrl tap-hold の 2 つだけになり、どちらも意図的に移していない項目
- フラッシュ 22,982 / 28,672（80.2%、+102 バイト）

## Testing / 動作確認

- [x] `bats tests` 26/26 pass
- [x] `qmk userspace-compile` が通る
- [x] 左右両方の Pro Micro に書き込み、verify 通過
- [x] 日本語入力中に `Ctrl+Space` → 英数に切り替わり、かつ tmux prefix として効く
- [x] 英数のまま `Ctrl+Space` → prefix として普通に効く
- [x] Ctrl なしの Space → 通常の空白

🤖 Generated with [Claude Code](https://claude.com/claude-code)