### PR TITLE
chore(karabiner): drop the obsolete Ctrl tap-hold rule

### DIFF
--- a/.config/karabiner/HRM.md
+++ b/.config/karabiner/HRM.md
@@ -4,10 +4,7 @@ source: `.config/karabiner/karabiner.ts` / `.config/zsh/command.sh` / `.config/t
 
 適用対象は **Mac 内蔵キーボードのみ** (`ifBuiltIn` = `device_if: is_built_in_keyboard`)。外付けキーボード (7sPro) は QMK 側でキーマップを完結させるため Karabiner を通さない。以下の Scope 列の「All apps」は内蔵キーボード上での話。
 
-7sPro 側にも同じ HRM・IME 切替・Ctrl ナビゲーションを実装済み (`.config/qmk/README.md`)。**残る差は 2 つだけ**:
-
-- **J = Shift** — QMK はホストのアプリを知らないため「vim 系アプリで無効」を再現できず、7sPro では載せていない
-- **ターミナルの Ctrl tap-hold** — prefix が `Ctrl+b` だった時代の対策 (#69) で前提が失われているため、意図的に移していない
+7sPro 側にも同じ HRM・IME 切替・Ctrl ナビゲーションを実装済み (`.config/qmk/README.md`)。**残る差は J = Shift だけ** — QMK はホストのアプリを知らないため「vim 系アプリで無効」を再現できず、7sPro では載せていない。
 
 ## Modifier mappings
 

--- a/.config/karabiner/karabiner.json
+++ b/.config/karabiner/karabiner.json
@@ -4,55 +4,8 @@
       "complex_modifications": {
         "rules": [
           {
-            "description": "Terminal Ctrl tap-hold + tmux IME bypass",
+            "description": "Terminal tmux IME bypass",
             "manipulators": [
-              {
-                "type": "basic",
-                "from": {
-                  "key_code": "left_control",
-                  "modifiers": {
-                    "optional": [
-                      "any"
-                    ]
-                  }
-                },
-                "to": [
-                  {
-                    "key_code": "left_control",
-                    "lazy": true
-                  }
-                ],
-                "to_if_alone": [
-                  {
-                    "key_code": "left_control",
-                    "hold_down_milliseconds": 300
-                  }
-                ],
-                "parameters": {
-                  "basic.to_if_alone_timeout_milliseconds": 300
-                },
-                "conditions": [
-                  {
-                    "type": "device_if",
-                    "identifiers": [
-                      {
-                        "is_built_in_keyboard": true
-                      }
-                    ]
-                  },
-                  {
-                    "type": "frontmost_application_if",
-                    "bundle_identifiers": [
-                      "^com\\.apple\\.Terminal$",
-                      "^com\\.googlecode\\.iterm2$",
-                      "^org\\.alacritty$",
-                      "^com\\.github\\.wez\\.wezterm$",
-                      "^com\\.mitchellh\\.ghostty$",
-                      "^net\\.kovidgoyal\\.kitty$"
-                    ]
-                  }
-                ]
-              },
               {
                 "type": "basic",
                 "from": {
@@ -9932,9 +9885,6 @@
       },
       "name": "Default profile",
       "selected": true,
-      "virtual_hid_keyboard": {
-        "keyboard_type_v2": "ansi"
-      },
       "simple_modifications": [
         {
           "to": [
@@ -9946,7 +9896,10 @@
             "key_code": "caps_lock"
           }
         }
-      ]
+      ],
+      "virtual_hid_keyboard": {
+        "keyboard_type_v2": "ansi"
+      }
     }
   ]
 }

--- a/.config/karabiner/karabiner.ts
+++ b/.config/karabiner/karabiner.ts
@@ -86,16 +86,7 @@ function homeRowMod(opts: {
 const SIMPLE_MODIFICATIONS = [map('caps_lock').to('left_control')];
 
 writeToProfile('Default profile', [
-  rule(
-    'Terminal Ctrl tap-hold + tmux IME bypass',
-    ifBuiltIn,
-    ifTerminal,
-  ).manipulators([
-    map({ key_code: 'left_control', modifiers: { optional: ['any'] } })
-      .to({ key_code: 'left_control', lazy: true })
-      .toIfAlone({ key_code: 'left_control', hold_down_milliseconds: 300 })
-      .parameters({ 'basic.to_if_alone_timeout_milliseconds': 300 }),
-
+  rule('Terminal tmux IME bypass', ifBuiltIn, ifTerminal).manipulators([
     map({
       key_code: 'spacebar',
       modifiers: { mandatory: ['left_control'], optional: ['any'] },

--- a/.config/qmk/README.md
+++ b/.config/qmk/README.md
@@ -140,8 +140,7 @@ Simple Modifications (`caps_lock` → `left_control`) だけは profile 全体�
 
 ### 移していないもの
 
-- **`J` = Shift**。Karabiner 側は vim 系アプリで無効化しているが、QMK はホストのアプリを知らないため同じ切り分けができない。7sPro では右 Shift は物理キーを使う
-- **ターミナルでの Ctrl tap-hold**。[PR #69](https://github.com/HagaSpa/dotfiles/pull/69) で「`Ctrl+b` を素早くタップして離した後に `b` を押すと単独の `b` になる」対策として入ったものだが、**tmux prefix はその後 `Ctrl+Space` に変わっており前提が失われている**。さらに `LCTL_T(KC_D)` が送る `left_control` を Karabiner が再度掴む二重処理のリスクがあるため、意図的に移していない
+**`J` = Shift** だけ。Karabiner 側は vim 系アプリで無効化しているが、QMK はホストのアプリを知らないため同じ切り分けができない。7sPro では右 Shift は物理キーを使う。
 
 ## VIA / Remap
 


### PR DESCRIPTION
## Background / 背景

ターミナルで `left_control` を単押ししたら 300ms ホールドし続けるルールを削除する。

これは [PR #69](https://github.com/HagaSpa/dotfiles/pull/69) で「caps_lock（→left_control）を素早くタップして離した後に `b` を押すと、Ctrl+b ではなく単独の `b` になる」対策として入ったもの。**当時の tmux prefix は `Ctrl+b` だった。**

その後 prefix は `Ctrl+Space`（`D` ホールド + 右親指 Space の bilateral chord）に変わっており、同手チョードを避ける設計になっている。加えて Home Row Mods の tap-hold は tap と hold が明確に分かれるため、「素早くタップして離してから相方を押す」という取りこぼしが起きにくい。前提が失われたルールが残っている状態だった。

7sPro への移植（#205〜#208）でこのルールを移すか検討した際に気づいたもの。

## Changes / 変更内容

- `karabiner.ts` から `left_control` の tap-hold manipulator を削除
- 同じ rule に含まれる tmux IME bypass（`Ctrl+Space` → 英数 + `Ctrl+Space`）は**残す**。こちらは現役なので、rule 名を実態に合わせて `Terminal tmux IME bypass` に変更した
- `HRM.md` / `.config/qmk/README.md` から、7sPro に移していない項目としての記述を削除（MacBook との差は `J`=Shift だけになった）

## Impact scope / 影響範囲

- ターミナルアプリでの `left_control` の挙動が素通しに戻る
- `Ctrl+Space` での IME 抜けは従来どおり動作する
- 生成される manipulator が 1 つ減る（`Terminal tmux IME bypass` は 1 manipulator）

## Testing / 動作確認

- [x] `bun run build` でプロファイル生成・リポジトリへの同期・リロードが通る
- [x] 生成された `karabiner.json` に `left_control` の tap-hold が無いことを確認
- [x] ターミナルで `Ctrl+Space` → 英数に切り替わり tmux prefix として効く
- [x] tmux prefix を素早く打っても取りこぼさない
- [x] `bats tests` 26/26 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)