### PR TITLE
feat(qmk): put Space on the left thumb home, Cmd beside it

### DIFF
--- a/.config/qmk/README.md
+++ b/.config/qmk/README.md
@@ -53,7 +53,7 @@ MacBook 内蔵キーボードでは Karabiner が同等の機能を提供して�
 
 `process_record_user()` の `ctrl_nav()` で実装。Ctrl のビットだけ落として送るので、`Ctrl+Shift+h` は `Shift+←` になり選択範囲が伸びる。
 
-Ctrl の出どころは `D` のホールド (HRM)、`A` の左、最下段の左から 2 番目のいずれでもよい。
+Ctrl の出どころは `D` のホールド (HRM) でも `A` の左でもよい。
 
 `Ctrl+h/j/k/l` を潰すので **nvim のウィンドウ移動 (`<C-w>hjkl` の別名) は使えない**。内蔵キーボードでも Karabiner が同じ変換をしていて元から機能していなかったため、`.config/nvim/lua/config/keymaps.lua` から該当の割り当てを外した。
 
@@ -66,17 +66,19 @@ Karabiner 側はこれをターミナル限定にしているが、QMK はフロ
 ### 最下段
 
 ```
-[MO(FN)][ Ctrl ][ Alt  ][Cmd/英数] │ [Space][ Cmd/かな ][ BS  ][Return]
-  1u      1.5u    1.5u    1.25u       1.25u     2u        1.5u    1u
-                         ^^^^^^^^      ^^^^^^^
-                      左親指ホーム    右親指ホーム
+[MO(FN)][ Opt  ][Cmd/英数][ Space ] │ [Space][ Cmd/かな ][ BS  ][Return]
+  1u      1.5u    1.5u      1.25u      1.25u     2u        1.5u    1u
+                           ^^^^^^^^     ^^^^^^^
+                        左親指ホーム   右親指ホーム
 ```
 
-**左手は MacBook の `cmd` から左をそのまま並べている** (`fn` `ctrl` `opt` `cmd`)。Cmd が最頻出かつ IME 切替も兼ねるので、MacBook と同じ「親指の定位置のすぐ内側」に置くことを最優先した。`fn` は Apple 独自実装で QMK から送れないため、その枠を `MO(_FN)` に充てている。
+**MacBook の `opt` `cmd` `Space` の並びをそのまま再現している。** 親指ホームが Space でその隣が Cmd なので、MacBook で指が覚えている相対位置と一致する。Cmd は最頻出で IME 切替も兼ねるため、この一致を優先した。
+
+`fn` は Apple 独自実装で QMK から送れないため、その枠を `MO(_FN)` に充てている。MacBook の `ctrl` の枠は `opt` に置き換えた — Ctrl は `A` の左と HRM の `D` で足りるが、**Option は物理キーがここだけ**になるため (右 Option は無い)。HRM の `S` だけに頼ると、HRM が効かない状況で Option を入力できなくなる。
 
 Home Row Mods のリファレンス実装 ([Miryoku](https://github.com/manna-harbour/miryoku)) は GUI を小指 (`A`) に載せる (GACS) ので最下段の Cmd を議論しない。ここでは `A` に HRM を載せない方針 (左手首腱鞘炎対策) を優先した結果、Cmd を物理キーとして親指に置く必要がある。
 
-Space は右親指のみ。左手側は修飾キーで埋まるが、実際に Space を打つのは右親指だけなので支障はない (左手が Ctrl / D / Cmd と組む側だから)。tmux prefix (`D` ホールド + Space = Ctrl+Space) もこの位置で成立する。
+Space は左右両方の親指ホームにある。tmux prefix (`D` ホールド + Space = Ctrl+Space) は右親指で打つ (左手は `D` を押している側なので)。
 
 BS と Return を親指に置いたのは、素の配置では BS が右上・Return が右手小指 (2.25u) で遠いため。`[9,3]` `[9,4]` は親指ホームから 2〜3 つ外側なので、指を伸ばす必要はある。
 

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
@@ -29,7 +29,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
       KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT, MO(_FN),
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
-               MO(_FN), KC_LCTL, KC_LALT, LGUI_T(KC_LNG2),   KC_SPC, RGUI_T(KC_LNG1), KC_BSPC,  KC_ENT
+               MO(_FN), KC_LALT, LGUI_T(KC_LNG2), KC_SPC,    KC_SPC, RGUI_T(KC_LNG1), KC_BSPC,  KC_ENT
           //`---------------------------------------------|   |--------------------------------------------'
   ),
 
@@ -72,7 +72,7 @@ const char chordal_hold_layout[MATRIX_ROWS][MATRIX_COLS] PROGMEM = LAYOUT(
   'L','L','L','L','L','L',    'R','R','R','R','R','R','R','R',
   'L','L','L','L','L','L',    'R','R','R','R','*','R','R',
   'L','L','L','L','L','L',    'R','R','R','R','R','R','R',
-      'L','L','L','*',        'R','*','R','R'
+      'L','L','*','L',        'R','*','R','R'
 );
 
 // Cmd has to engage the moment another key is pressed; waiting out TAPPING_TERM


### PR DESCRIPTION
## Background / 背景

#206 では左親指ホームを Cmd にしていたが、MacBook では同じ位置が Space であり、実際に打っていると差が残っていた。MacBook の `opt` `cmd` `Space` の並びをそのまま再現する。

あわせて最下段の Ctrl の枠を Option に置き換える。Ctrl は `A` の左と HRM の `D` の 2 経路あるのに対し、**Option は右 Option が無く HRM の `S` だけになっていた**。物理キーが 1 つも無いと、HRM が効かない状況で Option を入力できなくなる。

## Changes / 変更内容

```
変更前  [MO(FN)][ Ctrl ][  Opt   ][Cmd/英数]
変更後  [MO(FN)][ Opt  ][Cmd/英数][ Space  ]
                                  ^^^^^^^^^ 左親指ホーム

MacBook [fn]   [ctrl ][ opt ][ cmd ][ Space ]
                       ^^^^^^^^^^^^^^^^^^^^^ 並びが一致
```

- `chordal_hold_layout` の `'*'` を Cmd の新しい位置 `[4,3]` へ移した。`Cmd+A` `Cmd+C` のような同手チョードに必要
- Space が左右両方の親指ホームに載った

## Impact scope / 影響範囲

- **最下段から物理 Ctrl が消えた**。`A` の左と HRM の `D` で足りる
- Option は最下段の `[4,2]` と HRM の `S` の 2 経路になった
- tmux prefix (`D` ホールド + 右親指 Space) は変わらず右で打つ
- フラッシュサイズは変わらず 22,982 / 28,672（80.2%）

## Testing / 動作確認

- [x] `bats tests` 26/26 pass
- [x] `qmk userspace-compile` が通る
- [x] 左右両方の Pro Micro に書き込み、verify 通過
- [x] 左親指ホームで Space
- [x] その隣がタップで英数、ホールドで Cmd。`Cmd+A` / `Cmd+C` も動作（`'*'` handedness の移動を確認）
- [x] `[4,2]` で Option
- [x] Ctrl が `A` の左と `D` ホールドで効く
- [x] tmux prefix が動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)