### PR TITLE
fix(qmk): let Ctrl navigation repeat while held

### DIFF
--- a/.config/qmk/README.md
+++ b/.config/qmk/README.md
@@ -51,9 +51,9 @@ MacBook 内蔵キーボードでは Karabiner が同等の機能を提供して�
 | Ctrl + h / j / k / l | ← / ↓ / ↑ / → |
 | Ctrl + , / . | Opt + ← / → (word jump) |
 
-`process_record_user()` の `ctrl_nav()` で実装。Ctrl のビットだけ落として送るので、`Ctrl+Shift+h` は `Shift+←` になり選択範囲が伸びる。
+[Key Overrides](https://docs.qmk.fm/features/key_overrides) (`KEY_OVERRIDE_ENABLE`) で実装。押している間だけ Ctrl を報告から抑止して矢印を押し下げたままにするので、`Ctrl+Shift+h` は `Shift+←` になり選択範囲が伸び、**押しっぱなしでは OS のキーリピートがそのまま効く**。`process_record_user()` から `tap_code16()` を送る実装では 1 回で止まってしまう。
 
-Ctrl の出どころは `D` のホールド (HRM) でも `A` の左でもよい。
+トリガは**左 Ctrl 限定**。`;` ホールドの `RCAG_T` は右 Ctrl を含むため、`MOD_MASK_CTRL` にすると Raycast の ⌘⌥⌃ + `hjkl` を食う。左 Ctrl であれば出どころは `D` のホールド (HRM) でも `A` の左でもよい。
 
 `Ctrl+h/j/k/l` を潰すので **nvim のウィンドウ移動 (`<C-w>hjkl` の別名) は使えない**。内蔵キーボードでも Karabiner が同じ変換をしていて元から機能していなかったため、`.config/nvim/lua/config/keymaps.lua` から該当の割り当てを外した。
 
@@ -146,4 +146,4 @@ Simple Modifications (`caps_lock` → `left_control`) だけは profile 全体�
 
 ## VIA / Remap
 
-使わない。`rules.mk` を置かず `VIA_ENABLE` も有効にしていない。有効にすると EEPROM 側のキーマップが優先され、このディレクトリのソースと二重管理になる。
+使わない。`VIA_ENABLE` は有効にしていない。有効にすると EEPROM 側のキーマップが優先され、このディレクトリのソースと二重管理になる (`rules.mk` にあるのは `KEY_OVERRIDE_ENABLE` だけ)。

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
@@ -107,36 +107,29 @@ return state;
 }
 
 // Ctrl + hjkl / , / . → arrows and word jump, mirroring the Karabiner rule that
-// covers the built-in keyboard. The Ctrl bit is stripped so the app sees a bare
-// arrow; any other modifier held at the time (Shift, for selection) passes
-// through. Returns true when the key was replaced.
-static bool ctrl_nav(uint16_t keycode, keyrecord_t *record) {
-  if (!(get_mods() & MOD_MASK_CTRL)) {
-    return false;
-  }
-  if (!record->event.pressed) {
-    return true;  // the press already sent a complete tap
-  }
+// covers the built-in keyboard. Key overrides hold the replacement down for as
+// long as the trigger is held, so the host's own key repeat applies; sending a
+// tap from process_record_user instead would fire exactly once. Ctrl is
+// suppressed so the app sees a bare arrow, while other modifiers held at the
+// time (Shift, for selection) pass through.
+//
+// Left Ctrl only: RCAG_T(KC_SCLN) holds *right* Ctrl for the Raycast hotkey, and
+// matching MOD_MASK_CTRL would eat ⌘⌥⌃ + hjkl.
+const key_override_t ctrl_h_override    = ko_make_basic(MOD_LCTL, KC_H, KC_LEFT);
+const key_override_t ctrl_j_override    = ko_make_basic(MOD_LCTL, KC_J, KC_DOWN);
+const key_override_t ctrl_k_override    = ko_make_basic(MOD_LCTL, KC_K, KC_UP);
+const key_override_t ctrl_l_override    = ko_make_basic(MOD_LCTL, KC_L, KC_RIGHT);
+const key_override_t ctrl_comm_override = ko_make_basic(MOD_LCTL, KC_COMM, LALT(KC_LEFT));
+const key_override_t ctrl_dot_override  = ko_make_basic(MOD_LCTL, KC_DOT, LALT(KC_RIGHT));
 
-  uint16_t to_code;
-  switch (keycode) {
-    case KC_H:    to_code = KC_LEFT;        break;
-    case KC_J:    to_code = KC_DOWN;        break;
-    case KC_K:    to_code = KC_UP;          break;
-    case KC_L:    to_code = KC_RIGHT;       break;
-    case KC_COMM: to_code = LALT(KC_LEFT);  break;
-    case KC_DOT:  to_code = LALT(KC_RIGHT); break;
-    default:      return false;
-  }
-
-  const uint8_t saved = get_mods();
-  del_mods(MOD_MASK_CTRL);
-  send_keyboard_report();
-  tap_code16(to_code);
-  set_mods(saved);
-  send_keyboard_report();
-  return true;
-}
+const key_override_t *key_overrides[] = {
+  &ctrl_h_override,
+  &ctrl_j_override,
+  &ctrl_k_override,
+  &ctrl_l_override,
+  &ctrl_comm_override,
+  &ctrl_dot_override,
+};
 
 // Ctrl+Space (tmux prefix) drops out of the IME on the way through: 英数 first,
 // then the prefix itself. The Karabiner equivalent scopes this to terminals, but
@@ -181,14 +174,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
           }
         break;
     #endif
-    case KC_H:
-    case KC_J:
-    case KC_K:
-    case KC_L:
-    case KC_COMM:
-    case KC_DOT:
-      result = !ctrl_nav(keycode, record);
-      break;
     case KC_SPC:
       result = !ctrl_space_ime_bypass(record);
       break;

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/rules.mk
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/rules.mk
@@ -1,0 +1,1 @@
+KEY_OVERRIDE_ENABLE = yes


### PR DESCRIPTION
## Background / 背景

7sPro で `Ctrl + h/j/k/l/,/.` を押しっぱなしにしても矢印がリピートしなかった。

キーリピートは OS が「キーが押され続けている」HID レポートを見て生成する。旧実装は `process_record_user()` から `tap_code16()` で押下と解放を 1 回送るだけだったため、OS はリピートを開始できなかった。内蔵キーボード側の Karabiner は押している間ずっと矢印を押し下げたままにするので、そちらでは効いていた。

## Changes / 変更内容

`ctrl_nav()` を QMK の [Key Overrides](https://docs.qmk.fm/features/key_overrides) 6 本に置き換え、`rules.mk` で `KEY_OVERRIDE_ENABLE` を有効化した。Key Override はトリガーを押している間だけ Ctrl をレポートから抑止して矢印を押し下げたままに保つため、OS のキーリピートがそのまま効く。Ctrl の抑止はレポート生成時のマスク (`set_suppressed_override_mods()`) で、旧実装の `del_mods` / `set_mods` による `real_mods` の書き換えではない。

トリガーを左 Ctrl 限定 (`MOD_LCTL`) にした。旧実装の `MOD_MASK_CTRL` は右 Ctrl も拾うため、`;` ホールド (`RCAG_T` = 右 Ctrl+Alt+Gui) で Raycast の ⌘⌥⌃ + `hjkl` が矢印に食われていた。

## Impact scope / 影響範囲

7sPro のキーマップのみ。`Ctrl+Shift+h` → `Shift+←`（選択範囲の伸長）は従来どおりで、`Ctrl+Space` の IME バイパスは変更していない。

ファームサイズは 22982 → 24400 / 28672 bytes (85%, 残り 4272 bytes)。ATmega32U4 の残量は少ないので、次に機能を足すときはビルド後のサイズを見る。

## Testing / 動作確認

- [x] `qmk userspace-compile` 成功・サイズが 28672 bytes に収まる
- [x] `qmk flash` で左右両方に書き込み・24400 bytes verified
- [ ] 実機での挙動確認（`Ctrl+hjkl` の押しっぱなしリピート、`Ctrl+Shift+j` の選択伸長、`Ctrl+,/.` の word jump リピート、`;` ホールド + `j` が Raycast に届くこと、`Ctrl+Space` の tmux prefix）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
