### PR TITLE
chore(lazygit): migrate git.pagers to git.diffRenderers

### DIFF
--- a/.config/lazygit/config.yml
+++ b/.config/lazygit/config.yml
@@ -1,7 +1,7 @@
 gui:
   sidePanelWidth: 0.2
 git:
-  pagers:
+  diffRenderers:
     - colorArg: always
-      pager: delta --paging=never
+      command: delta --paging=never
   mainPanelSplitMode: horizontal


### PR DESCRIPTION
## Background / 背景

lazygit 0.64.0 が起動時に設定ファイルを書き換え、ワークツリーに差分が出ていた。`git.pagers` が `git.diffRenderers` に改名され (`config.migratePagersToDiffRenderers`)、キー `pager` も `command` になったため。`git.paging` → `git.pagers` → `git.diffRenderers` と改名が続いている。

旧キーのままでも migration が効いて動作はするが、起動ごとに同じ書き換えが走るのでワークツリーが常に dirty になる。

## Changes / 変更内容

lazygit 自身が書き出した形に追従した。delta の指定内容 (`delta --paging=never` / `colorArg: always`) は変わっておらず、キー名の改名のみ。

## Impact scope / 影響範囲

lazygit の diff 表示のみ。`~/.config/lazygit/config.yml` は symlink のまま維持されている (Karabiner のような atomic write による実ファイル化は起きない)。

## Testing / 動作確認

- [x] `~/.config/lazygit/config.yml` の symlink が保たれていることを確認
- [x] lazygit 0.64.0 が自身で書き出した形であることを確認 (バイナリ内の migration 定義と一致)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
