### PR TITLE
feat(nvim): add blink.cmp completion engine

### DIFF
--- a/.config/nvim/lazy-lock.json
+++ b/.config/nvim/lazy-lock.json
@@ -1,4 +1,5 @@
 {
+  "blink.cmp": { "branch": "main", "commit": "78336bc89ee5365633bcf754d93df01678b5c08f" },
   "gitsigns.nvim": { "branch": "main", "commit": "31d6fb2d618bca1482b9f274751ead5f03461408" },
   "kanagawa.nvim": { "branch": "master", "commit": "bb85e4bfc8d89b0e62c8fa53ccdd13d12e2f77b3" },
   "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },

--- a/.config/nvim/lua/config/lsp.lua
+++ b/.config/nvim/lua/config/lsp.lua
@@ -14,6 +14,11 @@ vim.diagnostic.config({
   },
 })
 
+-- Delta only: nvim merges this onto vim.lsp.protocol.make_client_capabilities().
+vim.lsp.config('*', {
+  capabilities = require('blink.cmp').get_lsp_capabilities({}, false),
+})
+
 -- Kubernetes schema scoped to bons8i-style kustomize layout.
 vim.lsp.config('yamlls', {
   cmd = { 'yaml-language-server', '--stdio' },
@@ -77,6 +82,5 @@ vim.api.nvim_create_autocmd('LspAttach', {
     lmap('<leader>rn', vim.lsp.buf.rename, 'Rename symbol')
     lmap('<leader>ca', vim.lsp.buf.code_action, 'Code action')
     lmap('<leader>d', vim.diagnostic.open_float, 'Show diagnostic under cursor')
-    vim.lsp.completion.enable(true, args.data.client_id, buf, { autotrigger = true })
   end,
 })

--- a/.config/nvim/lua/plugins/completion.lua
+++ b/.config/nvim/lua/plugins/completion.lua
@@ -1,0 +1,23 @@
+return {
+  {
+    'saghen/blink.cmp',
+    -- No lazy-loading handler: lua/config/lsp.lua requires this at startup.
+    version = '1.*',
+    opts = {
+      keymap = {
+        preset = 'default',
+        -- The preset's <C-space> is the tmux prefix (.config/tmux/tmux.conf).
+        ['<C-g>'] = { 'show', 'show_documentation', 'hide_documentation' },
+      },
+      completion = {
+        documentation = { auto_show = true, auto_show_delay_ms = 200 },
+        ghost_text = { enabled = true },
+      },
+      sources = {
+        default = { 'lsp', 'path', 'snippets', 'buffer' },
+      },
+      fuzzy = { implementation = 'prefer_rust_with_warning' },
+    },
+    opts_extend = { 'sources.default' },
+  },
+}


### PR DESCRIPTION
## Background / 背景

nvim の補完は `vim.lsp.completion` の autotrigger だけで、LSP 1 ソースのみだった。ファジー絞り込み・ドキュメント表示・パス補完が無く、他エディタと比べて補完体験が明確に劣っていた。

## Changes / 変更内容

- `lua/plugins/completion.lua` を追加し、`saghen/blink.cmp` を `v1.*` でピン。リリースタグ指定によりビルド済みの Rust ファジーマッチャがダウンロードされるため、cargo ビルドは不要
  - sources: `lsp` / `path` / `snippets` / `buffer`
  - ドキュメントの自動表示（200ms）と ghost text を有効化
  - キーマップは `default` preset。ただし preset の `<C-space>`（手動表示）は tmux の prefix と衝突して nvim に届かないため、`<C-g>` を追加で割り当て
- `lua/config/lsp.lua`
  - `vim.lsp.completion.enable(..., autotrigger = true)` を削除（blink と二重発火するため）
  - `vim.lsp.config('*', { capabilities = ... })` で blink の capabilities を全サーバーに適用。blink v1 は capabilities を自動登録しないため明示が必要。nvim 側が `make_client_capabilities()` にマージするので差分のみ渡している

## Impact scope / 影響範囲

- nvim の挿入モードの補完 UI 全般
- 全 LSP サーバー（yamlls / rust_analyzer / ts_ls / ty）に送られる client capabilities
- `mason` 不使用・PATH ベースの LSP 運用方針は変更なし

## Testing / 動作確認

- [x] `ty` を使った Python バッファで補完メニューが表示され、定義済み変数が LSP ソースから返ることを確認
- [x] LSP クライアントに blink の capabilities が反映されていることを確認（`snippetSupport` / `insertReplaceSupport` / `resolveSupport`）
- [x] nvim 既定の capabilities が維持されていることを確認（`textDocument.hover`）
- [x] ビルド済みバイナリ `libblink_cmp_fuzzy.dylib` が配置され、rust 実装がロードされることを確認
- [x] `bats tests/config.bats tests/link.bats` 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)