### PR TITLE
feat(herdr): add herdr with tmux-matched keybindings

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,52 @@
+# キーバインドは .config/tmux/tmux.conf に揃えてある。tmux 側を変えたらここも合わせる。
+# 既定値のまま tmux と一致するものは書いていない (prefix+c / n / p / x / z / ? /
+# h j k l / [ / 1..9、vi 風コピーモード、マウス操作)。
+
+[terminal]
+default_shell = "/bin/zsh"
+
+[keys]
+prefix = "ctrl+space"
+
+detach = "prefix+d"                              # herdr 既定は prefix+q
+copy_mode = ["prefix+[", "prefix+u"]             # tmux: bind u copy-mode -u
+split_vertical = ["prefix+v", "prefix+%"]        # 右に分割
+split_horizontal = ["prefix+minus", "prefix+\""] # 下に分割
+rename_tab = ["prefix+shift+t", "prefix+,"]      # tmux: rename-window
+close_tab = ["prefix+shift+x", "prefix+&"]       # tmux: kill-window
+last_pane = "prefix+;"                           # tmux: last-pane
+cycle_pane_next = ["prefix+tab", "prefix+o"]     # tmux: select-pane -t :.+
+swap_pane_left = ["prefix+shift+h", "prefix+{"]
+swap_pane_right = ["prefix+shift+l", "prefix+}"]
+workspace_picker = ["prefix+w", "prefix+s"]      # tmux: choose-tree / choose-session
+settings = "prefix+shift+s"                      # 既定の prefix+s は上に譲る
+
+# yazi を popup で開き、選んだファイルを呼び出し元ペインの nvim に渡す
+[[keys.command]]
+key = "prefix+y"
+type = "popup"
+command = "~/.config/herdr/yazi-picker.sh"
+width = "90%"
+height = "90%"
+
+# HRM (Home Row Mods) チートシート
+[[keys.command]]
+key = "prefix+m"
+type = "popup"
+command = "bat --style=plain --color=always --paging=always ~/.config/karabiner/HRM.md"
+width = "80%"
+height = "80%"
+
+# ツール横断のワークフロー早見表。実体は docs/terminal-workflow.md で、link.sh が
+# tmux 側のパスに貼っている
+[[keys.command]]
+key = "prefix+shift+m"
+type = "popup"
+command = "bat --style=plain --color=always --paging=always ~/.config/tmux/terminal-workflow.md"
+width = "80%"
+height = "80%"
+
+[ui]
+# サイドバーは常設せず prefix+b で出す。"compact" だと畳んでも細い状態バーが残る
+sidebar_start_collapsed = true
+sidebar_collapsed_mode = "hidden"

--- a/.config/herdr/yazi-picker.sh
+++ b/.config/herdr/yazi-picker.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+CALLER_PANE=$HERDR_ACTIVE_PANE_ID
+tmp=$(mktemp /tmp/yazi-chosen.XXXXXX)
+
+yazi --chooser-file="$tmp"
+
+# nvim は bracketed paste をモードに関係なくバッファ挿入として扱うため、`herdr pane
+# run` (paste) ではなく send-keys で 1 文字ずつ打つ必要がある
+send_literal() {
+  local text=$1 keys=() i ch
+  for ((i = 0; i < ${#text}; i++)); do
+    ch=${text:i:1}
+    [[ $ch == " " ]] && ch=space
+    keys+=("$ch")
+  done
+  herdr pane send-keys "$CALLER_PANE" "${keys[@]}" enter
+}
+
+if [[ -s "$tmp" ]]; then
+  # chooser-file は改行区切り。1 行ずつ実行させないため空白区切りに変換
+  paths=$(tr '\n' ' ' <"$tmp")
+  current_cmd=$(herdr pane process-info --pane "$CALLER_PANE" |
+    jq -r '.result.process_info.foreground_processes[0].name')
+
+  if [[ "$current_cmd" == "nvim" ]]; then
+    herdr pane send-keys "$CALLER_PANE" esc
+    send_literal ":args $paths"
+  else
+    herdr pane run "$CALLER_PANE" "nvim $paths"
+  fi
+fi
+
+rm -f "$tmp"

--- a/.config/herdr/yazi-picker.sh
+++ b/.config/herdr/yazi-picker.sh
@@ -4,6 +4,7 @@ set -uo pipefail
 
 CALLER_PANE=$HERDR_ACTIVE_PANE_ID
 tmp=$(mktemp /tmp/yazi-chosen.XXXXXX)
+trap 'rm -f "$tmp"' EXIT
 
 yazi --chooser-file="$tmp"
 
@@ -32,5 +33,3 @@ if [[ -s "$tmp" ]]; then
     herdr pane run "$CALLER_PANE" "nvim $paths"
   fi
 fi
-
-rm -f "$tmp"

--- a/Brewfile
+++ b/Brewfile
@@ -20,6 +20,7 @@ brew "gh"
 brew "git-delta"
 brew "lazygit" # launched in a float from nvim (Snacks.lazygit)
 brew "tmux"
+brew "herdr"
 brew "typescript-language-server" # LSP: js/ts (nvim)
 brew "crit"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ zsh -n <file>   # zsh configs and .zshrc / .zshenv
 - **Shell**: `.zshrc` / `.zshenv` (main) + `.config/zsh/` (alias.sh, command.sh, hosts/)
 - **Runtime**: `.mise.toml` (Node.js LTS, bun, gcloud, terraform, biome, rust + rust-analyzer)
 - **Git**: `.gitconfig` (personal) + `.gitconfig-olta` (work, includeIf), `.config/lazygit/config.yml` (delta pager; found via `LG_CONFIG_FILE` in `.zshenv`, since lazygit defaults to `~/Library/Application Support`)
-- **Terminal**: `.config/ghostty/config`, `.config/tmux/tmux.conf` (→ `~/.tmux.conf`)
+- **Terminal**: `.config/ghostty/config`, `.config/tmux/tmux.conf` (→ `~/.tmux.conf`), `.config/herdr/` (herdr; keybindings mirror tmux.conf — see below)
 - **Editor**: `.config/nvim/init.lua` (Neovim), `.config/zed/settings.json` (Zed)
 - **Prompt/Plugins**: `.config/starship/starship.toml` (→ `~/.config/starship.toml`), `.config/sheldon/plugins.toml`
 - **File Manager**: `.config/yazi/` (yazi config + projects plugin)
@@ -62,6 +62,19 @@ zsh -n <file>   # zsh configs and .zshrc / .zshenv
 - **Browser**: `.config/vimium/vimium-c.json` (Vimium C settings export; import-only, not symlinked — see `.config/vimium/README.md`)
 - **Window Manager**: `.config/amethyst/amethyst.yml` (Amethyst; `screen-padding-*` is tied to the external monitor's logical width — see `docs/window-manager.md`)
 - **Claude Code**: `.config/claude/` (settings.json + commands/, symlinked to `~/.claude/`)
+
+### herdr (agent multiplexer)
+`.config/herdr/config.toml` mirrors `.config/tmux/tmux.conf`'s keybindings so the two multiplexers are interchangeable by muscle memory — change one and change the other. Apply edits to a running server without restarting panes:
+
+```bash
+herdr config check          # validate config.toml (also a bats test)
+herdr server reload-config  # apply to the running server
+herdr --default-config      # full annotated default config
+```
+
+Four tmux bindings have no herdr equivalent in 0.8.0 and are deliberately absent: `send-prefix`, `last-window`, `PageUp` as a bindable key, and rebinding keys *inside* copy mode. See `docs/herdr-vs-tmux.md`.
+
+`.config/herdr/yazi-picker.sh` is the herdr port of `.config/tmux/yazi-picker.sh`. It sends the chosen paths to nvim with `herdr pane send-keys` one character at a time, not `herdr pane run` — `run` pastes via bracketed paste, which nvim inserts into the buffer regardless of mode.
 
 ### Karabiner (TypeScript build)
 `karabiner.json` is generated from `karabiner.ts` using the karabiner.ts library. Never edit `karabiner.json` directly, and never add Simple Modifications from the Karabiner GUI (they live in `karabiner.ts`'s `SIMPLE_MODIFICATIONS` too) — edit `karabiner.ts` and build:
@@ -84,7 +97,7 @@ Do NOT add `.config/qmk/` to `link.sh` — `overlay_dir` points at the in-repo p
 Karabiner's complex modifications are scoped to the built-in keyboard, so they never apply to the 7sPro; anything the 7sPro needs (Home Row Mods included) lives in the keymap. See `.config/qmk/README.md`.
 
 ### Docs
-`docs/` holds decision records and troubleshooting notes (terminal-workflow cheatsheet, cmux-vs-tmux, karabiner-vs-nix, brew-vs-nix, brew-vs-mise-bootstrap, editor-strategy, raycast-dotfiles, secure-input-hotkey-outage, terminal-scrollback, gui-app-path, window-manager) and the tooling-roadmap (planned improvements with adopt/reject status). The terminal-workflow cheatsheet is symlinked for the tmux Prefix+M popup.
+`docs/` holds decision records and troubleshooting notes (terminal-workflow cheatsheet, cmux-vs-tmux, herdr-vs-tmux, karabiner-vs-nix, brew-vs-nix, brew-vs-mise-bootstrap, editor-strategy, raycast-dotfiles, secure-input-hotkey-outage, terminal-scrollback, gui-app-path, window-manager) and the tooling-roadmap (planned improvements with adopt/reject status). The terminal-workflow cheatsheet is symlinked for the tmux Prefix+M popup.
 
 ### Workspace Conventions
 Custom shell functions assume this structure:

--- a/docs/herdr-vs-tmux.md
+++ b/docs/herdr-vs-tmux.md
@@ -1,0 +1,72 @@
+# herdr のキーバインドを tmux に揃える (2026-08)
+
+herdr 0.8.0 を導入し、`.config/tmux/tmux.conf` のキーバインドを `.config/herdr/config.toml` に移植した記録。**結論: 押すキーはほぼ完全に一致させられた。再現できないのは 4 つだけ。**
+
+herdr は tmux と同じ prefix モデルを持つ多重化ツール（Rust + Ratatui）で、pane / tab / session に加えて「AI エージェントの状態（working / blocked / done / idle）をサイドバーに出す」層が乗っている。`herdr --default-config` が全設定項目の注釈付きリストを出す。
+
+## 一致させたもの
+
+prefix を `ctrl+space` にした上で、herdr の既定が tmux とズレていた箇所だけを上書きしている。既定のまま一致するもの（`prefix+c` / `n` / `p` / `x` / `z` / `?` / `[` / `h j k l` / `1..9`、vi 風コピーモード、マウス操作）は書いていない。
+
+| tmux | herdr | 対応 |
+|---|---|---|
+| `prefix Ctrl+Space` (prefix 自体) | `prefix = "ctrl+space"` | ✅ |
+| `prefix d` detach | `detach` の既定は `prefix+q` | ✅ 上書き |
+| `prefix u` copy-mode (自前 bind) | `copy_mode = ["prefix+[", "prefix+u"]` | ✅ tmux 既定の `[` も残した |
+| `prefix %` / `prefix "` 分割 | `split_vertical` / `split_horizontal` の既定は `prefix+v` / `prefix+minus` | ✅ 両方受ける |
+| `prefix ,` rename-window | `rename_tab` の既定は `prefix+shift+t` | ✅ 両方受ける |
+| `prefix &` kill-window | `close_tab` の既定は `prefix+shift+x` | ✅ 両方受ける |
+| `prefix ;` last-pane | `last_pane` は既定で未割当 | ✅ 割当 |
+| `prefix o` 次のペイン | `cycle_pane_next` の既定は `prefix+tab` | ✅ 両方受ける |
+| `prefix {` / `}` swap-pane | `swap_pane_left` / `_right` の既定は `prefix+shift+h` / `+l` | ✅ 両方受ける |
+| `prefix w` / `prefix s` ツリー選択 | `workspace_picker` (既定 `prefix+w`) | ✅ `prefix+s` も割当。既定でここにあった `settings` は `prefix+shift+s` に退避 |
+| `prefix y` yazi popup | `[[keys.command]] type = "popup"` | ✅ スクリプトは要移植（下記） |
+| `prefix m` / `prefix M` チートシート popup | 同上 | ✅ |
+| `bind c new-window -c '#{pane_current_path}'` | `[terminal] new_cwd = "follow"` が既定 | ✅ 設定不要 |
+| `set -g default-shell /bin/zsh` | `[terminal] default_shell` | ✅ |
+| `setw -g mode-keys vi` | herdr のコピーモードは元から vi 風 | ✅ 設定不要 |
+| `set -g mouse on` | `[ui] mouse_capture = true` が既定 | ✅ 設定不要 |
+| `set -g history-limit 10000` | `[advanced] scrollback_limit_bytes = 10000000` が既定 | ✅ tmux より広い |
+
+## 再現できないもの
+
+`herdr --default-config` に出る全アクション名（バイナリ側の一覧とも突き合わせた）に該当するものが無い。
+
+1. **`bind C-Space send-prefix`** — prefix そのものをペインに送るアクションが無い。入れ子（herdr の中で tmux を動かす等）で prefix を透過させられない。
+2. **`bind Space last-window`** — `last_pane` はあるが「直前の tab」に相当するアクションが無い。CLI の `herdr tab` にも直前 tab の状態は出ないので、シェルスクリプトで状態ファイルを持つ手はあるが、`prefix+n` やクリックで tab を移ると値が腐る（tmux は全ての切り替えを追跡する）。plugin の `[[events]]` に tab フォーカスイベントがあれば正しく作れるが、v1 で公開されているのは `worktree.created` だけ。
+3. **`bind -n PPage ...`** — `PageUp` がそもそもバインド可能なキーではない（`pageup` / `page_up` / `pgup` いずれも `invalid keybinding`。通るのは `backspace` / `space` / `esc` / `enter` / `tab` と英数字・記号）。加えて herdr には `if-shell -F '#{alternate_on}'` に相当する条件分岐が無いので、「代替画面のアプリには素通し、それ以外はコピーモード」という振り分けも書けない。**修飾キー無しスクロールは `prefix+u` 側だけが残る。**
+4. **コピーモード内のキー再割当** — `[keys]` にあるのは「コピーモードに入る」`copy_mode` だけで、モード内のキー（herdr は `ctrl+u` / `ctrl+d` で半ページ）は設定に出てこない。`.config/tmux/tmux.conf` が `copy-mode-vi` の `u` / `d` を半ページに割り当てているのは真似できない。ghostty 側に `keybind = ctrl+u=text:\x15` があるので `ctrl+u` は herdr には届く。
+
+## tmux 側にあって herdr では別の仕組みになるもの
+
+キーバインドではないが、移植時に引っかかった点。
+
+- **ステータスライン** — `status-style` / `window-status-current-format` の `λ #I` のような書式文字列は無い。herdr はテーマ（`[theme] name`、11 種の組み込み）とサイドバー行レイアウト（`[ui.sidebar.*] rows`）で見た目を決める。
+- **tmux-resurrect / tmux-continuum** — herdr はサーバー常駐でペインが生き続けるので日常的な復元は不要。マシン再起動を挟む復元は `[session] resume_agents_on_restore`（エージェントの会話セッション復帰）と `[experimental] pane_history` が担当し、resurrect のような「ペインのコマンドラインを保存して再実行」とは別物。
+- **`allow-passthrough on`** — yazi の画像プレビューに使っていたパススルーは `[experimental] kitty_graphics` に相当するが既定 off。
+- **`automatic-rename off`** — 自動リネーム自体が無く、`[ui] prompt_new_tab_name = true`（既定）が tab 作成時に名前を訊く。
+- **`prefix 0`** — `switch_tab` は `prefix+1..9` 固定（`prefix+0..9` は `invalid keybinding`）。tmux は window 0 から始まるのでここだけ 1 つずれる。
+
+## yazi popup の移植
+
+`.config/tmux/yazi-picker.sh` の herdr 版が `.config/herdr/yazi-picker.sh`。置き換えたのは 3 箇所。
+
+| tmux | herdr |
+|---|---|
+| `$1`（popup 起動時に `#{pane_id}` を渡す） | 環境変数 `HERDR_ACTIVE_PANE_ID` |
+| `tmux display-message -p '#{pane_current_command}'` | `herdr pane process-info --pane <id>` の `foreground_processes[0].name` |
+| `tmux send-keys` | nvim なら `herdr pane send-keys`、シェルなら `herdr pane run` |
+
+**`herdr pane run` / `send-text` を nvim に向けて使ってはいけない。** どちらも bracketed paste で送るため、nvim はモードに関係なくバッファへの挿入として扱う（`:args ...` がそのまま本文に入る）。`herdr pane send-keys` は生のキー入力になるが、引数は 1 トークン 1 キーで、複数文字のトークンはキー名として解釈される（`:args!` は `unsupported key`）。そのため 1 文字ずつ配列に展開して渡している。
+
+また、tmux 版が `tmux new-session` で yazi を包んでいたのは popup がパススルー非対応で画像プレビューが壊れるからだったが、herdr 版は popup で直接 yazi を起動している（`kitty_graphics` が既定 off なので画像プレビューはどちらでも出ない）。
+
+## 検証に使ったコマンド
+
+`herdr config check` は構文しか見ないが、無効なバインドは名前付きで落としてくれるので、キー名の可否はこれで潰せる。設定パスは `HERDR_CONFIG_PATH` で差し替えられるので、本番の `~/.config/herdr/config.toml` を触らずに試せる。
+
+```bash
+HERDR_CONFIG_PATH=/tmp/probe.toml herdr config check   # 構文 + キー名の検証
+herdr server reload-config                             # 稼働中サーバーに反映（diagnostics が空なら OK）
+herdr api snapshot                                     # 稼働中の状態を JSON で見る
+```

--- a/link.sh
+++ b/link.sh
@@ -10,6 +10,8 @@ entries=(
   .config/amethyst/amethyst.yml
   .config/fd/config
   .config/ghostty/config
+  .config/herdr/config.toml
+  .config/herdr/yazi-picker.sh
   .config/karabiner/HRM.md
   .config/karabiner/karabiner.json
   .config/lazygit/config.yml

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -33,6 +33,11 @@ setup() {
   tmux -f .config/tmux/tmux.conf list-keys >/dev/null 2>&1
 }
 
+@test "herdr configuration is valid" {
+  command -v herdr >/dev/null 2>&1 || skip "herdr not available"
+  HERDR_CONFIG_PATH="$PWD/.config/herdr/config.toml" herdr config check
+}
+
 @test "karabiner.json is valid JSON" {
   python3 -m json.tool .config/karabiner/karabiner.json >/dev/null
 }


### PR DESCRIPTION
## Background / 背景

エージェント多重化ツール [herdr](https://herdr.dev/) 0.8.0 をトライアル導入する。tmux と同じ prefix モデルの上に「エージェントの状態 (working / blocked / done / idle) をサイドバーに出す」層が乗っている。

tmux から乗り換える形で試すため、**押すキーが tmux と一致していないと評価できない**。そのためキーバインドを `.config/tmux/tmux.conf` に揃えた。

## Changes / 変更内容

- `Brewfile` に `brew "herdr"` を追加
- `.config/herdr/config.toml` を追加。prefix を `ctrl+space` にし、herdr の既定が tmux とズレていた箇所だけを上書き（`detach` / `copy_mode` / 分割 / `rename_tab` / `close_tab` / `last_pane` / `cycle_pane_next` / `swap_pane_*` / `workspace_picker`）。既定のまま一致するものは書いていない
- popup 3 つを `[[keys.command]]` で移植（`prefix y` yazi / `prefix m` HRM / `prefix M` ワークフロー表）
- `.config/herdr/yazi-picker.sh` を追加。tmux 版の herdr 移植で、`#{pane_id}` → `HERDR_ACTIVE_PANE_ID`、`#{pane_current_command}` → `herdr pane process-info`、`tmux send-keys` → `herdr pane send-keys` に置き換えた。**nvim には `herdr pane run` を使えない**（bracketed paste で送るためモードに関係なくバッファ挿入になる）ので 1 文字ずつ送っている
- サイドバーは `[ui] sidebar_start_collapsed` + `sidebar_collapsed_mode = "hidden"` で常設せず、`prefix+b` で出す
- `link.sh` に 2 エントリ追加。`~/.config/herdr/` には `herdr.sock` とログも入るのでディレクトリごとではなくファイル単位で貼る
- `docs/herdr-vs-tmux.md` を追加。対応表と、再現できなかった 4 つ（`send-prefix` / `last-window` / `PageUp` のバインド / コピーモード内のキー再割当）を記録
- `tests/config.bats` に `herdr config check` を追加（tmux の syntax テストと同じ位置づけ）

## Impact scope / 影響範囲

- **新規ツールの追加のみで、既存の tmux 環境には影響しない。** tmux.conf は変更していない
- herdr と tmux は同じ層のツールなので入れ子にはしない（prefix が両方 `ctrl+space` で衝突する。herdr には `send-prefix` が無いため herdr を外側にすると内側の tmux が操作不能になる）
- `~/.config/herdr/config.toml` は herdr の設定画面から書き戻される可能性がある。設定変更は repo 側を編集して `herdr server reload-config` で反映する
- `herdr integration install claude` は未実行。書き込み先の `~/.claude/settings.json` が repo への symlink で、既存の `Notification` / `Stop` フックと衝突しうる

## Testing / 動作確認

- [x] `herdr config check` が `config: ok`（キー名の可否は `HERDR_CONFIG_PATH` で本番設定を触らずに検証。`pageup` / `prefix+0..9` は `invalid keybinding` と判明）
- [x] 稼働中サーバーへの `herdr server reload-config` が `diagnostics: []` / `status: applied`
- [x] `bats tests/link.bats tests/config.bats tests/brewfile.bats` が 21 件すべて pass（`herdr configuration is valid` を含む）
- [x] `./link.sh` で `~/.config/herdr/config.toml` と `yazi-picker.sh` の symlink が張れる
- [x] shellcheck / shfmt -i 2 -d が pass
- [x] `herdr pane send-keys` で nvim に `:args <path>` が渡ることを実機確認（`herdr pane run` ではバッファに挿入されてしまうことも確認）