### PR TITLE
feat(qmk): move modifiers to thumbs and add a NAV layer

### DIFF
--- a/.config/qmk/README.md
+++ b/.config/qmk/README.md
@@ -25,22 +25,23 @@ mise run qmk   # toolchain + qmk_firmware clone + overlay_dir 登録
 
 ![7sPro keymap](keymap.svg)
 
-MacBook 内蔵キーボードでは Karabiner が同等の機能を提供している (`../karabiner/HRM.md`)。持ち替えたときの操作感を揃えるため、同じものを QMK 側に実装している。
+MacBook 内蔵キーボードでは Karabiner が近い機能を提供している (`../karabiner/HRM.md`)。整合を取るのは**ホームローの tap-hold だけ**で、最下段は 7sPro 独自 (親指の到達性を優先。2026-08-07 に方針変更)。**レイヤ方式への移行はまだ Karabiner に追随させていない** — 内蔵側は S=Opt / D=Ctrl+変換のまま。
 
-### Home Row Mods
+### ホームローの tap-hold
 
 | キー | ホールド |
 |---|---|
-| F | Shift |
-| S | Option |
-| D | Control |
+| S | `_FN` レイヤ (F1–F12) |
+| D | `_NAV` レイヤ (矢印ほか、下記) |
+| F | Shift (右手の文字用) |
+| Enter (右親指) | Shift (左手の文字用) |
 | ; | ⌘⌥⌃ (Raycast 用) |
 
-`A` には載せない (左手首腱鞘炎対策)。`J` にも載せない — Karabiner 側は vim 系アプリで無効化しているが、**QMK はホストのアプリを知らないため同じ切り分けができない**。7sPro では右 Shift は物理キーを使う。
+修飾キーの mod-tap (S=Opt, D=Ctrl) からレイヤ方式に移行した (2026-08-07)。D=Ctrl だった頃は **`Ctrl+D` が原理的に作れず** (D 自身が Ctrl)、同手の `Ctrl+G` / `Ctrl+B` も `CHORDAL_HOLD` がタップに倒していた。Ctrl を左親指の専用キーに出したことで、この制約ごと消えている。
 
-`CHORDAL_HOLD` が同手のロールをタップ扱いにするので、`fa` のような同手ロールで Shift が誤爆しない。**ただし効くのは `TAPPING_TERM` (180ms) 以内**で、意図的に同手で修飾子を使いたいときは長めにホールドしてから相方を叩く (Karabiner 側も同じ運用)。加えて `FLOW_TAP_TERM` が高速タイプ中のホールド判定を止める。
+Shift が 2 箇所あるのも `CHORDAL_HOLD` の帰結 — F ホールドは同手 (左手) の文字に効かないので、左手の大文字は右親指の Enter ホールドで打つ。`A` には載せない (左手首腱鞘炎対策)。`J` にも載せない — vim の j/k 長押しスクロールが死ぬため (Karabiner 側は vim 系アプリで無効化しているが、QMK はホストのアプリを知らない)。
 
-**`Ctrl+D` は D が Ctrl 自身なので HRM では作れない。** 同手の `Ctrl+G` / `Ctrl+B` / `Ctrl+F` も `CHORDAL_HOLD` がタップに倒す。これらはホームロー左端の物理 `KC_LCTL` を使う。
+`CHORDAL_HOLD` が同手のロールをタップ扱いにするので、`fa` や `ds` のような同手ロールで誤爆しない。**ただし効くのは `TAPPING_TERM` (180ms) 以内**で、意図的に同手で使いたいときは長めにホールドしてから相方を叩く。加えて `FLOW_TAP_TERM` (150ms) が高速タイプ中のホールド判定を止める — **文字入力の直後はホールドがタップに倒れる**ので、タイプ直後の矢印や Shift は一呼吸置く。
 
 ### Cmd 単押しで IME
 
@@ -48,43 +49,47 @@ MacBook 内蔵キーボードでは Karabiner が同等の機能を提供して�
 
 `get_hold_on_other_key_press()` で Cmd だけ「他キー押下で即ホールド確定」にしている。`TAPPING_TERM` を待つと `Cmd+C` が鈍く感じるため。
 
-### Ctrl ナビゲーション
+### NAV レイヤ (D ホールド)
 
 | 入力 | 出力 |
 |---|---|
-| Ctrl + h / j / k / l | ← / ↓ / ↑ / → |
-| Ctrl + , / . | Opt + ← / → (word jump) |
+| D + h / j / k / l | ← / ↓ / ↑ / → |
+| D + , / . | Opt + ← / → (word jump) |
+| D + u / n | PgUp / PgDn |
+| D + 左親指 BS | Del (forward delete) |
 
-[Key Overrides](https://docs.qmk.fm/features/key_overrides) (`KEY_OVERRIDE_ENABLE`) で実装。押している間だけ Ctrl を報告から抑止して矢印を押し下げたままにするので、`Ctrl+Shift+h` は `Shift+←` になり選択範囲が伸び、**押しっぱなしでは OS のキーリピートがそのまま効く**。`process_record_user()` から `tap_code16()` を送る実装では 1 回で止まってしまう。
+以前は Key Overrides で `Ctrl+hjkl` → 矢印に変換していた (トリガは物理 Ctrl か D=Ctrl の HRM)。指の動きは D ホールド + hjkl のまま、経路から Ctrl を外した形。矢印はレイヤが直接発行するので、選択を伸ばすときは Enter 親指か物理 Shift を重ねる。
 
-トリガは**左 Ctrl 限定**。`;` ホールドの `RCAG_T` は右 Ctrl を含むため、`MOD_MASK_CTRL` にすると Raycast の ⌘⌥⌃ + `hjkl` を食う。左 Ctrl であれば出どころは `D` のホールド (HRM) でも `A` の左でもよい。
+`CHORDAL_HOLD` の逆手ルールと相性がよい — D は左手、対象キーはすべて右手なので同手ロールで誤爆しない。唯一の例外が左親指 BS で、これだけ chordal_hold_layout で `'*'` (除外) にして同手チョードを許可している。
 
-`Ctrl+h/j/k/l` を潰すので **nvim のウィンドウ移動 (`<C-w>hjkl` の別名) は使えない**。内蔵キーボードでも Karabiner が同じ変換をしていて元から機能していなかったため、`.config/nvim/lua/config/keymaps.lua` から該当の割り当てを外した。
+Ctrl+hjkl の変換が消えたので、**素の `Ctrl+h/j/k/l` がアプリまで届くようになった** (ターミナルの Ctrl+L = clear などが復活)。nvim のウィンドウ移動 (`<C-w>hjkl` の別名) は、内蔵キーボード側の Karabiner がまだ同じ変換をしているため `.config/nvim/lua/config/keymaps.lua` では無効のまま。
 
 ### tmux prefix と IME
 
-`Ctrl+Space` (`D` ホールド + 右親指 Space) は、先に 英数 (`KC_LNG2`) を送ってから `Ctrl+Space` を送る。日本語入力中でも prefix を打つだけで IME から抜けられる。
+`Ctrl+Space` (左親指 Ctrl + 右親指 Space) は、先に 英数 (`KC_LNG2`) を送ってから `Ctrl+Space` を送る。日本語入力中でも prefix を打つだけで IME から抜けられる。左右対称の親指チョードなので小指もタイミング調整も要らない (herdr も同じ prefix)。
 
 Karabiner 側はこれをターミナル限定にしているが、QMK はフロントのアプリを判定できないため **全アプリ対象**。`Ctrl+Space` に他の割り当てが無いので支障はない (macOS 自身の入力ソース切替は `settings.sh` で無効化済み)。
 
 ### 最下段
 
 ```
-[MO(FN)][ Opt  ][Cmd/英数][ Space ] │ [Space][ Cmd/かな ][ BS  ][Return]
-  1u      1.5u    1.5u      1.25u      1.25u     2u        1.5u    1u
-                           ^^^^^^^^     ^^^^^^^
-                        左親指ホーム   右親指ホーム
+[MO(FN)][  BS  ][Cmd/英数][ Ctrl ] │ [Space][ Cmd/かな ][Enter/Shift][ Opt ]
+  1u      1.5u    1.5u     1.25u     1.25u      2u         1.5u        1u
+ 小指/薬指 ギリ親指  親指ホーム  楽々     楽々     親指ホーム    ギリ親指    小指/薬指
 ```
 
-**MacBook の `opt` `cmd` `Space` の並びをそのまま再現している。** 親指ホームが Space でその隣が Cmd なので、MacBook で指が覚えている相対位置と一致する。Cmd は最頻出で IME 切替も兼ねるため、この一致を優先した。
+当初は MacBook の `opt` `cmd` `Space` の並びを再現していたが、**頻度基準の並びに変更した** (2026-08-07)。7sPro は内蔵キーボードより横に広く、物理 Ctrl / Shift への左小指の伸びが痛みの原因になったため。MacBook と揃えるのはホームローだけとし、最下段は 7sPro 専用の体で慣らす。
 
-`fn` は Apple 独自実装で QMK から送れないため、その枠を `MO(_FN)` に充てている。MacBook の `ctrl` の枠は `opt` に置き換えた — Ctrl は `A` の左と HRM の `D` で足りるが、**Option は物理キーがここだけ**になるため (右 Option は無い)。HRM の `S` だけに頼ると、HRM が効かない状況で Option を入力できなくなる。
+配置原則は**到達性と頻度の一致**:
 
-Home Row Mods のリファレンス実装 ([Miryoku](https://github.com/manna-harbour/miryoku)) は GUI を小指 (`A`) に載せる (GACS) ので最下段の Cmd を議論しない。ここでは `A` に HRM を載せない方針 (左手首腱鞘炎対策) を優先した結果、Cmd を物理キーとして親指に置く必要がある。
+- **一番外 (1u)** は親指が届かない。低頻度キー (`MO(_FN)` / `Opt`) 専用にして、押すときはホームポジションを外して薬指で押す
+- **外から 2 番目 (1.5u)** はギリ親指圏 — 手を少しスライドして親指をたたむと届く。キーキャップを上下逆に付けて凸面を親指側に向けると多少良くなる。ここに BS (左) と Enter/Shift (右)
+- **親指ホーム** (左 1.5u / 右 2u) は Cmd ペア。**かな Cmd に 2u を充てているのは、最頻出ホールドのチョードアンカーだから** — Cmd+C/V のホールド中は親指の接地点がズレるので、面積がそのまま脱落防止になる。単発タップ (Space 等) は 1.25u で外さない
+- **Ctrl は左親指** (旧・左 Space の位置。Space は右親指でしか打っていなかった)。tmux prefix が左右対称の親指チョードになり、ターミナルの Ctrl コードも親指起点になる
 
-Space は左右両方の親指ホームにある。tmux prefix (`D` ホールド + Space = Ctrl+Space) は右親指で打つ (左手は `D` を押している側なので)。
+Enter ホールドの Shift は左手の文字専用 (chordal_hold_layout で `'R'` のまま)。右手文字との同手ロール (`l` → Enter など) が Shift に化けないための線引きで、右手の大文字は F ホールドが担当する。
 
-BS と Return を親指に置いたのは、素の配置では BS が右上・Return が右手小指 (2.25u) で遠いため。`[9,3]` `[9,4]` は親指ホームから 2〜3 つ外側なので、指を伸ばす必要はある。
+BS と Enter は素の位置 (右上 / 右小指 2.25u) にも残っているので、遠いと感じる場面ではそちらも使える。物理 Ctrl (`A` の左) と物理 Shift (左下) は矯正期間の保険として残置。
 
 ### 図の再生成
 
@@ -94,7 +99,7 @@ mise run qmk-keymap   # keymap.c → keymap.svg
 
 [keymap-drawer](https://github.com/caksoylar/keymap-drawer) が `qmk c2json` の出力を描画する。`keymap.c` を変えたら走らせる。SVG はテキストなので diff が読める。
 
-図は 4 レイヤーで、うち 3 つは `keymaps[][][]` から自動生成される。**4 枚目の `Ctrl 併用` だけは `keymap-notes.yaml` に手で書いている** — Key Overrides と `Ctrl+Space` の IME 先送りは `keymaps` の外にあり、`c2json` からは見えないため。`keymap.c` のこれらを変えたら手で追随させる。
+図は 5 レイヤーで、うち 4 つは `keymaps[][][]` から自動生成される。**5 枚目の `Ctrl 併用` だけは `keymap-notes.yaml` に手で書いている** — `Ctrl+Space` の IME 先送りは `process_record_user()` にあり、`c2json` からは見えないため。`keymap.c` のこれを変えたら手で追随させる。
 
 `keymap-drawer.yaml` はラベルの読み替え (`KC_LNG2` → 英数 など)。`parse_config.qmk_keycode_map` に書くと組み込みの対応表ごと置き換わってしまうので、`raw_binding_map` を使っている。
 
@@ -115,7 +120,7 @@ ATmega32U4 なので UF2 のドラッグ&ドロップではなく avrdude 書き
 
 キーマップから入れる。物理リセットは不要。
 
-1. `MO(_FN)` を押しながら — 左親指ホーム、または最下段の 1 つ上の右端
+1. `MO(_FN)` を押しながら — 最下段の左端、または最下段の 1 つ上の右端
 2. **左上 Esc の位置**を押す — `_FN` レイヤーの `TG(_ADJUST)` に当たる
 3. `MO(_FN)` を離す
 4. **右上 Grave (`~`) の位置**を押す — `_ADJUST` レイヤーの `QK_BOOT`
@@ -152,7 +157,7 @@ QMK CLI の設定は `~/.config/qmk/` ではなく `~/Library/Application Suppor
 
 ## Karabiner との責務分割
 
-Complex modifications は `ifBuiltIn` で内蔵キーボードに限定してあるので、7sPro には効かない。HRM と IME 切替は上記のとおり QMK 側で実装済み。
+Complex modifications は `ifBuiltIn` で内蔵キーボードに限定してあるので、7sPro には効かない。ホームローの tap-hold と IME 切替は上記のとおり QMK 側で実装済み。
 
 Simple Modifications (`caps_lock` → `left_control`) だけは profile 全体に効くが、このキーマップは caps lock を送らず該当位置に直接 `KC_LCTL` を置いているので衝突しない。詳細は `../karabiner/README.md`。
 
@@ -162,4 +167,4 @@ Simple Modifications (`caps_lock` → `left_control`) だけは profile 全体�
 
 ## VIA / Remap
 
-使わない。`VIA_ENABLE` は有効にしていない。有効にすると EEPROM 側のキーマップが優先され、このディレクトリのソースと二重管理になる (`rules.mk` にあるのは `KEY_OVERRIDE_ENABLE` だけ)。
+使わない。`VIA_ENABLE` は有効にしていない。有効にすると EEPROM 側のキーマップが優先され、このディレクトリのソースと二重管理になる (追加機能を有効にしていないので `rules.mk` 自体が無い)。

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/config.h
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/config.h
@@ -21,9 +21,10 @@
 #define QUICK_TAP_TERM 0
 #define TAPPING_TERM 180
 
-/* Home Row Mods. CHORDAL_HOLD settles same-hand chords as taps, so only
- * opposite-hand chords produce a modifier; it requires PERMISSIVE_HOLD or
- * HOLD_ON_OTHER_KEY_PRESS to define the opposite-hand case. */
+/* Home row tap-holds (S/D layer-taps, F Shift) and the thumb Enter Shift.
+ * CHORDAL_HOLD settles same-hand chords as taps, so only opposite-hand chords
+ * produce a hold; it requires PERMISSIVE_HOLD or HOLD_ON_OTHER_KEY_PRESS to
+ * define the opposite-hand case. */
 #define CHORDAL_HOLD
 #define PERMISSIVE_HOLD
 #define FLOW_TAP_TERM 150

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/keymap.c
@@ -11,6 +11,7 @@ extern uint8_t is_master;
 enum layer_number {
   _QWERTY = 0,
   _FN,
+  _NAV,
   _ADJUST,
 };
 
@@ -25,11 +26,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------+--------+--------|
        KC_TAB,    KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,        KC_Y,    KC_U,    KC_I,    KC_O,    KC_P, KC_LBRC, KC_RBRC, KC_BSPC,
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------+--------|
-      KC_LCTL,    KC_A, LALT_T(KC_S), LCTL_T(KC_D), LSFT_T(KC_F), KC_G,  KC_H,    KC_J,    KC_K,    KC_L, RCAG_T(KC_SCLN), KC_QUOT, KC_ENT,
+      KC_LCTL,    KC_A, LT(_FN, KC_S), LT(_NAV, KC_D), LSFT_T(KC_F), KC_G,  KC_H,  KC_J,    KC_K,    KC_L, RCAG_T(KC_SCLN), KC_QUOT, KC_ENT,
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
       KC_LSFT,    KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,        KC_N,    KC_M, KC_COMM,  KC_DOT, KC_SLSH, KC_RSFT, MO(_FN),
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
-               MO(_FN), KC_LALT, LGUI_T(KC_LNG2), KC_SPC,    KC_SPC, RGUI_T(KC_LNG1), KC_BSPC,  KC_ENT
+               MO(_FN), KC_BSPC, LGUI_T(KC_LNG2), KC_LCTL,    KC_SPC, RGUI_T(KC_LNG1), RSFT_T(KC_ENT), KC_LALT
           //`---------------------------------------------|   |--------------------------------------------'
   ),
 
@@ -44,6 +45,20 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
       _______, _______, _______, _______, _______, _______,     _______, _______,  KC_END, KC_PGDN, KC_DOWN, _______, _______,
   //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
                _______, _______, _______, _______,              _______, _______,          KC_STOP, _______
+          //`---------------------------------------------|   |--------------------------------------------'
+  ),
+
+  [_NAV] = LAYOUT(
+  //,-----------------------------------------------------|   |--------------------------------------------------------------------------------.
+      _______, _______, _______, _______, _______, _______,     _______, _______, _______, _______, _______, _______, _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------+--------+--------|
+      _______, _______, _______, _______, _______, _______,     _______, KC_PGUP, _______, _______, _______, _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
+      _______, _______, _______, _______, _______, _______,     KC_LEFT, KC_DOWN,   KC_UP, KC_RGHT, _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
+      _______, _______, _______, _______, _______, _______,     KC_PGDN, _______, LALT(KC_LEFT), LALT(KC_RGHT), _______, _______, _______,
+  //|--------+--------+--------+--------+--------+--------|   |--------+--------+--------+--------+--------+--------+--------|
+               _______,  KC_DEL, _______, _______,              _______, _______,          _______, _______
           //`---------------------------------------------|   |--------------------------------------------'
   ),
 
@@ -66,17 +81,22 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 // '*' exempts a key from Chordal Hold's opposite-hands rule. The Cmd mod-taps
 // need same-hand chords (Cmd+A, Cmd+C) and ; sends ⌘⌥⌃ to Raycast, whose
 // hotkey may sit on the right hand. Marking them 'L'/'R' would settle those as
-// taps and emit 英数 / かな / ; instead of the modifier.
+// taps and emit 英数 / かな / ; instead of the modifier. The left thumb
+// Backspace is exempt so D-hold (_NAV, same hand) can chord it into Delete.
+// The Enter thumb stays 'R' on purpose: Shift there only serves left-hand
+// letters, right-hand letters use F-hold, so an Enter→letter roll on the right
+// hand cannot misfire into Shift.
 const char chordal_hold_layout[MATRIX_ROWS][MATRIX_COLS] PROGMEM = LAYOUT(
   'L','L','L','L','L','L',    'R','R','R','R','R','R','R','R','R',
   'L','L','L','L','L','L',    'R','R','R','R','R','R','R','R',
   'L','L','L','L','L','L',    'R','R','R','R','*','R','R',
   'L','L','L','L','L','L',    'R','R','R','R','R','R','R',
-      'L','L','*','L',        'R','*','R','R'
+      'L','*','*','L',        'R','*','R','R'
 );
 
 // Cmd has to engage the moment another key is pressed; waiting out TAPPING_TERM
-// would make Cmd+C feel sluggish. The home row mods stay on PERMISSIVE_HOLD.
+// would make Cmd+C feel sluggish. The home row taps and the Enter Shift stay
+// on PERMISSIVE_HOLD.
 bool get_hold_on_other_key_press(uint16_t keycode, keyrecord_t *record) {
   switch (keycode) {
     case LGUI_T(KC_LNG2):
@@ -105,31 +125,6 @@ layer_state_t layer_state_set_user(layer_state_t state) {
 #endif
 return state;
 }
-
-// Ctrl + hjkl / , / . → arrows and word jump, mirroring the Karabiner rule that
-// covers the built-in keyboard. Key overrides hold the replacement down for as
-// long as the trigger is held, so the host's own key repeat applies; sending a
-// tap from process_record_user instead would fire exactly once. Ctrl is
-// suppressed so the app sees a bare arrow, while other modifiers held at the
-// time (Shift, for selection) pass through.
-//
-// Left Ctrl only: RCAG_T(KC_SCLN) holds *right* Ctrl for the Raycast hotkey, and
-// matching MOD_MASK_CTRL would eat ⌘⌥⌃ + hjkl.
-const key_override_t ctrl_h_override    = ko_make_basic(MOD_LCTL, KC_H, KC_LEFT);
-const key_override_t ctrl_j_override    = ko_make_basic(MOD_LCTL, KC_J, KC_DOWN);
-const key_override_t ctrl_k_override    = ko_make_basic(MOD_LCTL, KC_K, KC_UP);
-const key_override_t ctrl_l_override    = ko_make_basic(MOD_LCTL, KC_L, KC_RIGHT);
-const key_override_t ctrl_comm_override = ko_make_basic(MOD_LCTL, KC_COMM, LALT(KC_LEFT));
-const key_override_t ctrl_dot_override  = ko_make_basic(MOD_LCTL, KC_DOT, LALT(KC_RIGHT));
-
-const key_override_t *key_overrides[] = {
-  &ctrl_h_override,
-  &ctrl_j_override,
-  &ctrl_k_override,
-  &ctrl_l_override,
-  &ctrl_comm_override,
-  &ctrl_dot_override,
-};
 
 // Ctrl+Space (tmux prefix) drops out of the IME on the way through: 英数 first,
 // then the prefix itself. The Karabiner equivalent scopes this to terminals, but

--- a/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/rules.mk
+++ b/.config/qmk/keyboards/salicylic_acid3/7skb/keymaps/7spro/rules.mk
@@ -1,1 +1,0 @@
-KEY_OVERRIDE_ENABLE = yes

--- a/.config/qmk/keymap-drawer.yaml
+++ b/.config/qmk/keymap-drawer.yaml
@@ -10,9 +10,19 @@ parse_config:
     "LGUI_T(KC_LNG2)": {t: 英数, h: Cmd}
     "RGUI_T(KC_LNG1)": {t: かな, h: Cmd}
     "RCAG_T(KC_SCLN)": {t: ";", h: ⌘⌥⌃}
-    "LALT_T(KC_S)": {t: S, h: Opt}
-    "LCTL_T(KC_D)": {t: D, h: Ctrl}
+    "LT(_FN, KC_S)": {t: S, h: FN}
+    "LT(_NAV, KC_D)": {t: D, h: NAV}
     "LSFT_T(KC_F)": {t: F, h: Shift}
+    "RSFT_T(KC_ENT)": {t: Enter, h: Shift}
+    "LALT(KC_LEFT)": ⌥←
+    "LALT(KC_RGHT)": ⌥→
+    "KC_LEFT": ←
+    "KC_DOWN": ↓
+    "KC_UP": ↑
+    "KC_RGHT": →
+    "KC_PGUP": PgUp
+    "KC_PGDN": PgDn
+    "KC_DEL": Del
     "KC_LCTL": Ctrl
     "KC_LSFT": Shift
     "KC_RSFT": Shift

--- a/.config/qmk/keymap-notes.yaml
+++ b/.config/qmk/keymap-notes.yaml
@@ -1,6 +1,6 @@
 # Hand-written layer merged on top of the generated ones. keymaps[][][] is the
-# only thing qmk c2json can see, so Key Overrides and the Ctrl+Space IME bypass
-# would otherwise be absent from the drawing entirely.
+# only thing qmk c2json can see, so the Ctrl+Space IME bypass would otherwise
+# be absent from the drawing entirely.
 #
 # Row lengths follow LAYOUT: 15 / 14 / 13 / 13 / 8. The layer key must match the
 # --virtual-layers name in mise-tasks/qmk-keymap.
@@ -8,6 +8,6 @@ layers:
   Ctrl 併用:
     - ['', '', '', '', '', '', '', '', '', '', '', '', '', '', '']
     - ['', '', '', '', '', '', '', '', '', '', '', '', '', '']
-    - [{t: Ctrl, type: held}, '', '', {t: D, h: Ctrl, type: held}, '', '', ←, ↓, ↑, →, '', '', '']
-    - ['', '', '', '', '', '', '', '', ⌥←, ⌥→, '', '', '']
-    - ['', '', '', {t: tmux prefix, h: 英数を先送り}, {t: tmux prefix, h: 英数を先送り}, '', '', '']
+    - [{t: Ctrl, type: held}, '', '', '', '', '', '', '', '', '', '', '', '']
+    - ['', '', '', '', '', '', '', '', '', '', '', '', '']
+    - ['', '', '', {t: Ctrl, type: held}, {t: tmux prefix, h: 英数を先送り}, '', '', '']

--- a/.config/qmk/keymap.svg
+++ b/.config/qmk/keymap.svg
@@ -1,4 +1,4 @@
-<svg width="956" height="1400" viewBox="0 0 956 1400" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="956" height="1736" viewBox="0 0 956 1736" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags */
 svg path {
     fill: inherit;
@@ -265,13 +265,15 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(182, 140)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">S</text>
-<text x="0" y="24" class="key hold">Opt</text>
-</g>
+<a href="#FN">
+<text x="0" y="24" class="key hold layer-activator">FN</text>
+</a></g>
 <g transform="translate(238, 140)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">D</text>
-<text x="0" y="24" class="key hold">Ctrl</text>
-</g>
+<a href="#NAV">
+<text x="0" y="24" class="key hold layer-activator">NAV</text>
+</a></g>
 <g transform="translate(294, 140)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">F</text>
@@ -372,7 +374,7 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(182, 252)" class="key keypos-56">
 <rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key"/>
-<text x="0" y="0" class="key tap">Opt</text>
+<text x="0" y="0" class="key tap">BSPC</text>
 </g>
 <g transform="translate(266, 252)" class="key keypos-57">
 <rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key"/>
@@ -381,7 +383,7 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(343, 252)" class="key keypos-58">
 <rect rx="6" ry="6" x="-33" y="-26" width="66" height="52" class="key"/>
-<text x="0" y="0" class="key tap">SPC</text>
+<text x="0" y="0" class="key tap">Ctrl</text>
 </g>
 <g transform="translate(469, 252)" class="key keypos-59">
 <rect rx="6" ry="6" x="-33" y="-26" width="66" height="52" class="key"/>
@@ -394,11 +396,12 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(658, 252)" class="key keypos-61">
 <rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key"/>
-<text x="0" y="0" class="key tap">BSPC</text>
+<text x="0" y="0" class="key tap">Enter</text>
+<text x="0" y="24" class="key hold">Shift</text>
 </g>
 <g transform="translate(728, 252)" class="key keypos-62">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">ENT</text>
+<text x="0" y="0" class="key tap">Opt</text>
 </g>
 </g>
 </g>
@@ -465,7 +468,7 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(868, 28)" class="key keypos-14">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">DEL</text>
+<text x="0" y="0" class="key tap">Del</text>
 </g>
 <g transform="translate(42, 84)" class="key trans keypos-15">
 <rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key trans"/>
@@ -513,7 +516,7 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(728, 84)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">UP</text>
+<text x="0" y="0" class="key tap">↑</text>
 </g>
 <g transform="translate(784, 84)" class="key trans keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -561,11 +564,11 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(630, 140)" class="key keypos-38">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">PGUP</text>
+<text x="0" y="0" class="key tap">PgUp</text>
 </g>
 <g transform="translate(686, 140)" class="key keypos-39">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">LEFT</text>
+<text x="0" y="0" class="key tap">←</text>
 </g>
 <g transform="translate(742, 140)" class="key keypos-40">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -613,11 +616,11 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(658, 196)" class="key keypos-51">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">PGDN</text>
+<text x="0" y="0" class="key tap">PgDn</text>
 </g>
 <g transform="translate(714, 196)" class="key keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">DOWN</text>
+<text x="0" y="0" class="key tap">↓</text>
 </g>
 <g transform="translate(791, 196)" class="key trans keypos-53">
 <rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key trans"/>
@@ -661,7 +664,264 @@ path.combo { stroke: #7f7f7f; }
 </g>
 </g>
 </g>
-<g transform="translate(30, 672)" class="layer-ADJUST">
+<g transform="translate(30, 672)" class="layer-NAV">
+<text x="0" y="28" class="label" id="NAV">NAV</text>
+<g transform="translate(0, 56)">
+<g transform="translate(28, 28)" class="key trans keypos-0">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(84, 28)" class="key trans keypos-1">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(140, 28)" class="key trans keypos-2">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(196, 28)" class="key trans keypos-3">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(252, 28)" class="key trans keypos-4">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(308, 28)" class="key trans keypos-5">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(420, 28)" class="key trans keypos-6">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(476, 28)" class="key trans keypos-7">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(532, 28)" class="key trans keypos-8">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(588, 28)" class="key trans keypos-9">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(644, 28)" class="key trans keypos-10">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(700, 28)" class="key trans keypos-11">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(756, 28)" class="key trans keypos-12">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(812, 28)" class="key trans keypos-13">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(868, 28)" class="key trans keypos-14">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(42, 84)" class="key trans keypos-15">
+<rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(112, 84)" class="key trans keypos-16">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(168, 84)" class="key trans keypos-17">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(224, 84)" class="key trans keypos-18">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(280, 84)" class="key trans keypos-19">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(336, 84)" class="key trans keypos-20">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(448, 84)" class="key trans keypos-21">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(504, 84)" class="key keypos-22">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">PgUp</text>
+</g>
+<g transform="translate(560, 84)" class="key trans keypos-23">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(616, 84)" class="key trans keypos-24">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(672, 84)" class="key trans keypos-25">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(728, 84)" class="key trans keypos-26">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(784, 84)" class="key trans keypos-27">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(854, 84)" class="key trans keypos-28">
+<rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(49, 140)" class="key trans keypos-29">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(126, 140)" class="key trans keypos-30">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(182, 140)" class="key trans keypos-31">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(238, 140)" class="key trans keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(294, 140)" class="key trans keypos-33">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(350, 140)" class="key trans keypos-34">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(462, 140)" class="key keypos-35">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">←</text>
+</g>
+<g transform="translate(518, 140)" class="key keypos-36">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">↓</text>
+</g>
+<g transform="translate(574, 140)" class="key keypos-37">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">↑</text>
+</g>
+<g transform="translate(630, 140)" class="key keypos-38">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">→</text>
+</g>
+<g transform="translate(686, 140)" class="key trans keypos-39">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(742, 140)" class="key trans keypos-40">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(833, 140)" class="key trans keypos-41">
+<rect rx="6" ry="6" x="-61" y="-26" width="122" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(63, 196)" class="key trans keypos-42">
+<rect rx="6" ry="6" x="-61" y="-26" width="122" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(154, 196)" class="key trans keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(210, 196)" class="key trans keypos-44">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(266, 196)" class="key trans keypos-45">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(322, 196)" class="key trans keypos-46">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(378, 196)" class="key trans keypos-47">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(490, 196)" class="key keypos-48">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">PgDn</text>
+</g>
+<g transform="translate(546, 196)" class="key trans keypos-49">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(602, 196)" class="key keypos-50">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌥←</text>
+</g>
+<g transform="translate(658, 196)" class="key keypos-51">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">⌥→</text>
+</g>
+<g transform="translate(714, 196)" class="key trans keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(791, 196)" class="key trans keypos-53">
+<rect rx="6" ry="6" x="-47" y="-26" width="94" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(868, 196)" class="key trans keypos-54">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(112, 252)" class="key trans keypos-55">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(182, 252)" class="key keypos-56">
+<rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key"/>
+<text x="0" y="0" class="key tap">Del</text>
+</g>
+<g transform="translate(266, 252)" class="key trans keypos-57">
+<rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(343, 252)" class="key trans keypos-58">
+<rect rx="6" ry="6" x="-33" y="-26" width="66" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(469, 252)" class="key trans keypos-59">
+<rect rx="6" ry="6" x="-33" y="-26" width="66" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(560, 252)" class="key trans keypos-60">
+<rect rx="6" ry="6" x="-54" y="-26" width="108" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(658, 252)" class="key trans keypos-61">
+<rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+<g transform="translate(728, 252)" class="key trans keypos-62">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
+</g>
+</g>
+</g>
+<g transform="translate(30, 1008)" class="layer-ADJUST">
 <text x="0" y="28" class="label" id="ADJUST">ADJUST</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 28)" class="key keypos-0">
@@ -887,7 +1147,7 @@ path.combo { stroke: #7f7f7f; }
 </g>
 </g>
 </g>
-<g transform="translate(30, 1008)" class="layer-Ctrl 併用">
+<g transform="translate(30, 1344)" class="layer-Ctrl 併用">
 <text x="0" y="28" class="label" id="Ctrl-">Ctrl 併用</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 28)" class="key keypos-0">
@@ -987,10 +1247,8 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(182, 140)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
-<g transform="translate(238, 140)" class="key held keypos-32">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key held"/>
-<text x="0" y="0" class="key held tap">D</text>
-<text x="0" y="24" class="key held hold">Ctrl</text>
+<g transform="translate(238, 140)" class="key keypos-32">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 </g>
 <g transform="translate(294, 140)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1000,19 +1258,15 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(462, 140)" class="key keypos-35">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">←</text>
 </g>
 <g transform="translate(518, 140)" class="key keypos-36">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↓</text>
 </g>
 <g transform="translate(574, 140)" class="key keypos-37">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">↑</text>
 </g>
 <g transform="translate(630, 140)" class="key keypos-38">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">→</text>
 </g>
 <g transform="translate(686, 140)" class="key keypos-39">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1049,11 +1303,9 @@ path.combo { stroke: #7f7f7f; }
 </g>
 <g transform="translate(602, 196)" class="key keypos-50">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⌥←</text>
 </g>
 <g transform="translate(658, 196)" class="key keypos-51">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">⌥→</text>
 </g>
 <g transform="translate(714, 196)" class="key keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1073,12 +1325,9 @@ path.combo { stroke: #7f7f7f; }
 <g transform="translate(266, 252)" class="key keypos-57">
 <rect rx="6" ry="6" x="-40" y="-26" width="80" height="52" class="key"/>
 </g>
-<g transform="translate(343, 252)" class="key keypos-58">
-<rect rx="6" ry="6" x="-33" y="-26" width="66" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.9em">tmux</tspan><tspan x="0" dy="1.2em">prefix</tspan>
-</text>
-<text x="0" y="24" class="key hold">英数を先送り</text>
+<g transform="translate(343, 252)" class="key held keypos-58">
+<rect rx="6" ry="6" x="-33" y="-26" width="66" height="52" class="key held"/>
+<text x="0" y="0" class="key held tap">Ctrl</text>
 </g>
 <g transform="translate(469, 252)" class="key keypos-59">
 <rect rx="6" ry="6" x="-33" y="-26" width="66" height="52" class="key"/>

--- a/mise-tasks/qmk-keymap
+++ b/mise-tasks/qmk-keymap
@@ -8,7 +8,7 @@ QMK_DIR="$PWD/.config/qmk"
 
 # Must match enum layer_number in keymap.c, plus the hand-written layer whose
 # name is the top-level key in keymap-notes.yaml.
-LAYER_NAMES=(QWERTY FN ADJUST)
+LAYER_NAMES=(QWERTY FN NAV ADJUST)
 NOTES_LAYER="Ctrl 併用"
 
 if ! command -v qmk >/dev/null 2>&1; then


### PR DESCRIPTION
## Background / 背景

7sPro は MacBook 内蔵キーボードより横に広く、物理 Ctrl (Caps 位置) と物理 Shift (左下) へ左小指を伸ばし続けた結果、**左小指が痛むようになった**。Ctrl+hjkl を矢印として多用していたことが負荷を大きくしていた。

あわせて herdr / tmux の prefix (Ctrl+Space) のミスも多かった。原因は `FLOW_TAP_TERM 150` で、文字入力直後 150ms 以内の D ホールドが強制的にタップに倒れるため。

7sPro をオフィスに持っていく前提に変わり、MacBook との一致より親指の活用を優先することにした。移行コストは許容する。

## Changes / 変更内容

**最下段 — 到達性と頻度で並べ直し**

```
変更前: [MO(FN)][ Opt  ][Cmd/英数][ Space ] │ [Space][Cmd/かな][ BS  ][Return]
変更後: [MO(FN)][  BS  ][Cmd/英数][ Ctrl  ] │ [Space][Cmd/かな][Enter/Shift][ Opt ]
```

- **Ctrl を左親指の専用キーに** (旧・左 Space の位置。Space は右親指でしか打っていなかった)。tap-hold ではない素の `KC_LCTL` なので prefix の誤爆が原理的に起きない
- **Enter を右親指に置き、ホールドで Shift** (左手の文字用)
- 親指が届かない一番外 (1u) は低頻度キー (`MO(_FN)` / `Opt`) 専用にし、薬指で押す

**ホームロー — mod-tap からレイヤタップへ**

- `LALT_T(KC_S)` → `LT(_FN, KC_S)`
- `LCTL_T(KC_D)` → `LT(_NAV, KC_D)`
- `LSFT_T(KC_F)` と `RCAG_T(KC_SCLN)` は変更なし

**`_NAV` レイヤ新設 (D ホールド)**

| 入力 | 出力 |
|---|---|
| D + h/j/k/l | ← ↓ ↑ → |
| D + , / . | ⌥← / ⌥→ (word jump) |
| D + u / n | PgUp / PgDn |
| D + 左親指 BS | Del |

指の動き (D ホールド + hjkl) は変えず、経路から Ctrl を外した形。左親指 BS だけ `chordal_hold_layout` で `'*'` にして同手チョードを許可している。

**Key Overrides を全削除** — 矢印がレイヤに移ったので不要。`KEY_OVERRIDE_ENABLE` だけだった `rules.mk` も削除した。

## Impact scope / 影響範囲

- **`Ctrl+D` が打てるようになった** — D が Ctrl 自身だった制約が消えた。同手の `Ctrl+G` / `Ctrl+B` も同様
- **素の `Ctrl+H` / `Ctrl+K` / `Ctrl+L` がアプリまで届くようになった** — Key Override が全アプリで食っていたため、ターミナルの `Ctrl+L` (clear) 等が使えなかった
- **Shift が 2 箇所になった** — `CHORDAL_HOLD` により F ホールドは同手 (左手) の文字に効かないため、左手の大文字は右親指 Enter ホールドで打つ
- 物理 Ctrl (`A` の左) と物理 Shift (左下) は矯正期間の保険として残置。BS / Enter も素の位置に残っている
- **MacBook 内蔵キーボード (Karabiner) は未追随** — S=Opt / D=Ctrl+変換のまま。D=NAV 相当に揃える対応は別 PR
- ファームサイズ 22,906 / 32,768 bytes (flash に余裕あり)

## Testing / 動作確認

- [x] `qmk userspace-compile` が通る
- [x] 実機に flash して動作確認 (左右両方)
- [x] prefix (左親指 Ctrl + 右親指 Space) で herdr が反応し、IME からも抜ける
- [x] D ホールド + hjkl で矢印、+ 左親指 BS で Del
- [x] Enter 親指ホールドで左手文字が大文字になる
- [x] `bats tests` 28 件 pass
- [x] `shellcheck` / `shfmt` (`mise-tasks/qmk-keymap`)
- [x] `mise run qmk-keymap` で keymap.svg が NAV レイヤ込みで再生成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)