### PR TITLE
feat(nvim): set up a Go environment with gopls

### DIFF
--- a/.config/nvim/lua/config/lsp.lua
+++ b/.config/nvim/lua/config/lsp.lua
@@ -60,7 +60,46 @@ vim.lsp.config('ty', {
   root_markers = { 'ty.toml', 'pyproject.toml', 'setup.py', '.git' },
 })
 
-vim.lsp.enable({ 'yamlls', 'rust_analyzer', 'ts_ls', 'ty' })
+-- gofumpt / staticcheck are built into gopls; there are no separate binaries.
+vim.lsp.config('gopls', {
+  cmd = { 'gopls' },
+  filetypes = { 'go', 'gomod', 'gowork', 'gotmpl' },
+  root_markers = { 'go.work', 'go.mod', '.git' },
+  settings = {
+    gopls = {
+      gofumpt = true,
+      staticcheck = true,
+      analyses = { unusedparams = true, shadow = true },
+    },
+  },
+})
+
+vim.lsp.enable({ 'yamlls', 'rust_analyzer', 'ts_ls', 'ty', 'gopls' })
+
+-- Go alone formats on save: the language expects imports to be maintained by the
+-- tooling, so editing one by hand is not part of the workflow.
+vim.api.nvim_create_autocmd('BufWritePre', {
+  group = augroup,
+  pattern = '*.go',
+  callback = function(args)
+    local client = vim.lsp.get_clients({ bufnr = args.buf, name = 'gopls' })[1]
+    if not client then
+      return
+    end
+    local params = vim.lsp.util.make_range_params(0, client.offset_encoding)
+    params.context = { only = { 'source.organizeImports' }, diagnostics = {} }
+    -- 1000ms is not enough for the first save of a session: gopls loads the package first.
+    local responses = vim.lsp.buf_request_sync(args.buf, 'textDocument/codeAction', params, 3000)
+    for _, response in pairs(responses or {}) do
+      for _, action in pairs(response.result or {}) do
+        if action.edit then
+          vim.lsp.util.apply_workspace_edit(action.edit, client.offset_encoding)
+        end
+      end
+    end
+    vim.lsp.buf.format({ bufnr = args.buf, async = false, timeout_ms = 3000 })
+  end,
+})
 
 vim.api.nvim_create_autocmd('LspAttach', {
   group = augroup,

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,6 +3,7 @@ idiomatic_version_file_enable_tools = ["node", "python", "go", "terraform", "rus
 
 [tools]
 node = "lts"
+go = "latest"
 bun = "latest"
 gcloud = "latest"
 terraform = "latest"

--- a/Brewfile
+++ b/Brewfile
@@ -22,6 +22,7 @@ brew "lazygit" # launched in a float from nvim (Snacks.lazygit)
 brew "tmux"
 brew "herdr"
 brew "typescript-language-server" # LSP: js/ts (nvim)
+brew "gopls" # LSP: go (nvim). gofumpt and staticcheck ship inside it -- do not add them separately
 brew "crit"
 
 # Kubernetes / YAML


### PR DESCRIPTION
## Background / 背景

nvim におけるgo 開発環境が未整備だった。`mise` に go 1.24.13 がインストールされていたものの `.mise.toml` に宣言されていなかったため、`go version` が `No version is set for shim: go` で失敗する状態だった。LSP も未設定。

## Changes / 変更内容

- `.mise.toml`: `go = "latest"` を宣言（1.26.5）
- `Brewfile`: `gopls` を追加。`mise registry` に gopls は存在しないため brew を選択
- `.config/nvim/lua/config/lsp.lua`: gopls の設定と、Go のみに効く保存時フォーマットの autocmd を追加

gofumpt と staticcheck は gopls に組み込まれているため、別バイナリは入れていない。gopls の設定でそれぞれ有効化している。

保存時に `source.organizeImports` を同期 code action で適用してから format をかける。Go は import をツールに管理させる前提の言語のため、Go だけこの autocmd を持つ。

## Impact scope / 影響範囲

- nvim: Go ファイル以外への影響はない。autocmd は `*.go` に限定し、gopls が attach していなければ何もしない
- プラグインの追加はなし（`lazy-lock.json` は変更していない）
- Zed 側は未対応。gopls は PATH から拾われるが、gofumpt / staticcheck の設定は nvim 側にのみ存在する

## Testing / 動作確認

- [x] `import` を欠いた未整形の Go ファイルを保存し、import 追加・インデント整形・関数先頭末尾の空行削除（gofumpt 固有の挙動）を確認
- [x] `b == true` に staticcheck の `S1002` が出ることを確認
- [x] `bats tests/brewfile.bats tests/config.bats` が 16 件すべてパス

タイムアウトは実測に基づき 3000ms にしている。既定の 1000ms ではセッション最初の保存に間に合わず、`[LSP][gopls] timeout` を出したまま保存だけ成功する（フォーマットが黙って効かない）状態になった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)